### PR TITLE
Added acr_values entry for SE BankID QR, and introduced a shared snippet

### DIFF
--- a/_includes/snippets/login-methods-and-path-encoded.md
+++ b/_includes/snippets/login-methods-and-path-encoded.md
@@ -1,0 +1,28 @@
+| **Login method** | **acr_values** | **base64 encoded** |
+| --- | --- | --- |
+| **Norwegian BankID** |
+| &nbsp;&nbsp;Mobile or Web (user choice):&nbsp;         | `urn:grn:authn:no:bankid` | `dXJuOmdybjphdXRobjpubzpiYW5raWQ=` |
+| **Norwegian Vipps Login** |
+| &nbsp;&nbsp;Login with Vipps app:&nbsp;                | `urn:grn:authn:no:vipps` | `dXJuOmdybjphdXRobjpubzp2aXBwcw==` |
+| **Swedish BankID** |
+| &nbsp;&nbsp;Same device:                               | `urn:grn:authn:se:bankid:same-device` | `dXJuOmdybjphdXRobjpzZTpiYW5raWQ6c2FtZS1kZXZpY2U=` |
+| &nbsp;&nbsp;Another device (aka mobile):&nbsp;         | `urn:grn:authn:se:bankid:another-device` | `dXJuOmdybjphdXRobjpzZTpiYW5raWQ6YW5vdGhlci1kZXZpY2U=` |
+| &nbsp;&nbsp;QR code:&nbsp;         | `urn:grn:authn:se:bankid:another-device:qr` | `dXJuOmdybjphdXRobjpzZTpiYW5raWQ6YW5vdGhlci1kZXZpY2U6cXI=` |
+| **Danish NemID** |
+| &nbsp;&nbsp;Personal with code card:&nbsp;             | `urn:grn:authn:dk:nemid:poces` | `dXJuOmdybjphdXRobjpkazpuZW1pZDpwb2Nlcw==` |
+| &nbsp;&nbsp;Employee with code card:&nbsp;             | `urn:grn:authn:dk:nemid:moces` | `dXJuOmdybjphdXRobjpkazpuZW1pZDptb2Nlcw==` |
+| &nbsp;&nbsp;Employee with code file:&nbsp;             | `urn:grn:authn:dk:nemid:moces:codefile` | `dXJuOmdybjphdXRobjpkazpuZW1pZDptb2Nlczpjb2RlZmlsZQ==` |
+| **Danish MitID** |
+| &nbsp;&nbsp;Level low:&nbsp;                           | `urn:grn:authn:dk:mitid:low` | `dXJuOmdybjphdXRobjpkazptaXRpZDpsb3c=` |
+| &nbsp;&nbsp;Level substantial:&nbsp;                   | `urn:grn:authn:dk:mitid:substantial` | `dXJuOmdybjphdXRobjpkazptaXRpZDpzdWJzdGFudGlhbA==` |
+| **Finish e-ID** |
+| &nbsp;&nbsp;BankID:                                    |`urn:grn:authn:fi:bankid` | `dXJuOmdybjphdXRobjpmaTpiYW5raWQ=` |
+| &nbsp;&nbsp;Mobile certificate (Mobiilivarmenne):&nbsp;|`urn:grn:authn:fi:mobile-id` | `dXJuOmdybjphdXRobjpmaTptb2JpbGUtaWQ=` |
+| &nbsp;&nbsp;Any of the two:                            |`urn:grn:authn:fi:all` | `dXJuOmdybjphdXRobjpmaTphbGw=` |
+| **Itsme** |
+| &nbsp;&nbsp;Basic:                                     | `urn:grn:authn:itsme:basic` | `dXJuOmdybjphdXRobjppdHNtZTpiYXNpYw==` |
+| &nbsp;&nbsp;Advanced:                                  | `urn:grn:authn:itsme:advanced` | `dXJuOmdybjphdXRobjppdHNtZTphZHZhbmNlZA==` |
+| **Belgium** |
+| &nbsp;&nbsp;Verified e-ID                              | `urn:grn:authn:be:eid:verified` | `dXJuOmdybjphdXRobjpiZTplaWQ6dmVyaWZpZWQ=` |
+| **Germany** |
+| &nbsp;&nbsp;Sofort (with Schufa check)                 | `urn:grn:authn:de:sofort` | `dXJuOmdybjphdXRobjpkZTpzb2ZvcnQ=` |

--- a/_includes/snippets/login-methods.md
+++ b/_includes/snippets/login-methods.md
@@ -14,6 +14,7 @@ The current list of possible values is:
 | **Swedish BankID** |
 | &nbsp;&nbsp;Same device:                               | `urn:grn:authn:se:bankid:same-device` |
 | &nbsp;&nbsp;Another device (aka mobile):&nbsp;         | `urn:grn:authn:se:bankid:another-device` |
+| &nbsp;&nbsp;QR code:&nbsp;         | `urn:grn:authn:se:bankid:another-device:qr` |
 | **Danish NemID** |
 | &nbsp;&nbsp;Personal with code card:&nbsp;             | `urn:grn:authn:dk:nemid:poces` |
 | &nbsp;&nbsp;Employee with code card:&nbsp;             | `urn:grn:authn:dk:nemid:moces` |

--- a/authentication/auth0.md
+++ b/authentication/auth0.md
@@ -61,30 +61,7 @@ For example, the `acr_values` of Norwegian BankID login method is `urn:grn:authn
 
 Below is a list of supported login methods with corresponding base64 encoded `acr_values`. Choose the once you intend to use.
 
-| **Login method** | **acr_values** | **base64 encoded** |
-| --- | --- | --- |
-| **Norwegian BankID** |
-| &nbsp;&nbsp;Mobile or Web (user choice):&nbsp;         | `urn:grn:authn:no:bankid` | `dXJuOmdybjphdXRobjpubzpiYW5raWQ=` |
-| **Norwegian Vipps Login** |
-| &nbsp;&nbsp;Login with Vipps app:&nbsp;                | `urn:grn:authn:no:vipps` | `dXJuOmdybjphdXRobjpubzp2aXBwcw==` |
-| **Swedish BankID** |
-| &nbsp;&nbsp;Same device:                               | `urn:grn:authn:se:bankid:same-device` | `dXJuOmdybjphdXRobjpzZTpiYW5raWQ6c2FtZS1kZXZpY2U=` |
-| &nbsp;&nbsp;Another device (aka mobile):&nbsp;         | `urn:grn:authn:se:bankid:another-device` | `dXJuOmdybjphdXRobjpzZTpiYW5raWQ6YW5vdGhlci1kZXZpY2U=` |
-| **Danish NemID** |
-| &nbsp;&nbsp;Personal with code card:&nbsp;             | `urn:grn:authn:dk:nemid:poces` | `dXJuOmdybjphdXRobjpkazpuZW1pZDpwb2Nlcw==` |
-| &nbsp;&nbsp;Employee with code card:&nbsp;             | `urn:grn:authn:dk:nemid:moces` | `dXJuOmdybjphdXRobjpkazpuZW1pZDptb2Nlcw==` |
-| &nbsp;&nbsp;Employee with code file:&nbsp;             | `urn:grn:authn:dk:nemid:moces:codefile` | `dXJuOmdybjphdXRobjpkazpuZW1pZDptb2Nlczpjb2RlZmlsZQ==` |
-| **Finish e-ID** |
-| &nbsp;&nbsp;BankID:                                    |`urn:grn:authn:fi:bankid` | `dXJuOmdybjphdXRobjpmaTpiYW5raWQ=` |
-| &nbsp;&nbsp;Mobile certificate (Mobiilivarmenne):&nbsp;|`urn:grn:authn:fi:mobile-id` | `dXJuOmdybjphdXRobjpmaTptb2JpbGUtaWQ=` |
-| &nbsp;&nbsp;Any of the two:                            |`urn:grn:authn:fi:all` | `dXJuOmdybjphdXRobjpmaTphbGw=` |
-| **Itsme** |
-| &nbsp;&nbsp;Basic:                                     | `urn:grn:authn:itsme:basic` | `dXJuOmdybjphdXRobjppdHNtZTpiYXNpYw==` |
-| &nbsp;&nbsp;Advanced:                                  | `urn:grn:authn:itsme:advanced` | `dXJuOmdybjphdXRobjppdHNtZTphZHZhbmNlZA==` |
-| **Belgium** |
-| &nbsp;&nbsp;Verified e-ID                              | `urn:grn:authn:be:eid:verified` | `dXJuOmdybjphdXRobjpiZTplaWQ6dmVyaWZpZWQ=` |
-| **Germany** |
-| &nbsp;&nbsp;Sofort (with Schufa check)                 | `urn:grn:authn:de:sofort` | `dXJuOmdybjphdXRobjpkZTpzb2ZvcnQ=` |
+{% include snippets/login-methods-and-path-encoded.md %} 
 
 <hr />
 

--- a/authentication/onelogin.md
+++ b/authentication/onelogin.md
@@ -86,31 +86,7 @@ This tutorial demonstrates how to integrate Criipto Verify with OneLogin. The fo
 <a name="loginmethods"></a>
 
 ## Supported login methods
-
-| **Login method** | **acr_values** | **base64 encoded** |
-| --- | --- | --- |
-| **Norwegian BankID** |
-| &nbsp;&nbsp;Mobile or Web (user choice):&nbsp;         | `urn:grn:authn:no:bankid` | `dXJuOmdybjphdXRobjpubzpiYW5raWQ=` |
-| **Norwegian Vipps Login** |
-| &nbsp;&nbsp;Login with Vipps app:&nbsp;                | `urn:grn:authn:no:vipps` | `dXJuOmdybjphdXRobjpubzp2aXBwcw==` |
-| **Swedish BankID** |
-| &nbsp;&nbsp;Same device:                               | `urn:grn:authn:se:bankid:same-device` | `dXJuOmdybjphdXRobjpzZTpiYW5raWQ6c2FtZS1kZXZpY2U=` |
-| &nbsp;&nbsp;Another device (aka mobile):&nbsp;         | `urn:grn:authn:se:bankid:another-device` | `dXJuOmdybjphdXRobjpzZTpiYW5raWQ6YW5vdGhlci1kZXZpY2U=` |
-| **Danish NemID** |
-| &nbsp;&nbsp;Personal with code card:&nbsp;             | `urn:grn:authn:dk:nemid:poces` | `dXJuOmdybjphdXRobjpkazpuZW1pZDpwb2Nlcw==` |
-| &nbsp;&nbsp;Employee with code card:&nbsp;             | `urn:grn:authn:dk:nemid:moces` | `dXJuOmdybjphdXRobjpkazpuZW1pZDptb2Nlcw==` |
-| &nbsp;&nbsp;Employee with code file:&nbsp;             | `urn:grn:authn:dk:nemid:moces:codefile` | `dXJuOmdybjphdXRobjpkazpuZW1pZDptb2Nlczpjb2RlZmlsZQ==` |
-| **Finish e-ID** |
-| &nbsp;&nbsp;BankID:                                    |`urn:grn:authn:fi:bankid` | `dXJuOmdybjphdXRobjpmaTpiYW5raWQ=` |
-| &nbsp;&nbsp;Mobile certificate (Mobiilivarmenne):&nbsp;|`urn:grn:authn:fi:mobile-id` | `dXJuOmdybjphdXRobjpmaTptb2JpbGUtaWQ=` |
-| &nbsp;&nbsp;Any of the two:                            |`urn:grn:authn:fi:all` | `dXJuOmdybjphdXRobjpmaTphbGw=` |
-| **Itsme** |
-| &nbsp;&nbsp;Basic:                                     | `urn:grn:authn:itsme:basic` | `dXJuOmdybjphdXRobjppdHNtZTpiYXNpYw==` |
-| &nbsp;&nbsp;Advanced:                                  | `urn:grn:authn:itsme:advanced` | `dXJuOmdybjphdXRobjppdHNtZTphZHZhbmNlZA==` |
-| **Belgium** |
-| &nbsp;&nbsp;Verified e-ID                              | `urn:grn:authn:be:eid:verified` | `dXJuOmdybjphdXRobjpiZTplaWQ6dmVyaWZpZWQ=` |
-| **Germany** |
-| &nbsp;&nbsp;Sofort (with Schufa check)                 | `urn:grn:authn:de:sofort` | `dXJuOmdybjphdXRobjpkZTpzb2ZvcnQ=` |
+{% include snippets/login-methods-and-path-encoded.md %} 
 
 <br />
 


### PR DESCRIPTION
for the supported acr_values table used by the Auth0 and OneLogin
articles.
Also added the MitID Low and Substantial entries to the table with the
base64 encoded values.