### PR TITLE
Replace the use of "keys" with "credentials"

### DIFF
--- a/src/pages/verify/e-ids/norwegian-bankid.mdx
+++ b/src/pages/verify/e-ids/norwegian-bankid.mdx
@@ -184,7 +184,7 @@ You can use the Criipto management dashboard [dashboard.criipto.com](https://das
 
 ## Ordering Norwegian BankID
 
-To start accepting real users with Norwegian BankID, you must first request your _client credentials_ - a set of secret keys - from the Norwegian BankID organisation.
+To start accepting real users with Norwegian BankID, you must first request your _client credentials_ from Bidbax. The credentials consists of a _client id_ and a _client secret_.
 
 <Highlight icon="file-lines">
 
@@ -220,7 +220,7 @@ Or feel free to reach out, either on [Slack](https://tiny.cc/criipto-slack) or v
 
 ### Ordering the client credentials
 
-To order the actual keys please send a request to 
+To order production credentials please send a request to 
 
 <p style="text-indent: 50px"><a href="mailto:support@criipto.com?subject=NO BankID for ...">support@criipto.com</a></p>
 
@@ -234,7 +234,7 @@ with answers to these questions:
 6. Contact person with authorization to block/revoke the use of BankID: _Name, mobile phone, and email_
 7. Person registered in the business registry with authorization to sign the agreement: _Name and email_
 8. If you need access to social security numbers (“fødselsnummer”) please provide brief explanation of why and reference the Norwegian law and paragraph that grant you the right
-9. Contact person with authorization to receive the secret keys: _Name, mobile phone, and email_
+9. Contact person with authorization to receive the credentials: _Name, mobile phone, and email_
 10. The display name to appear in the login app. E.g. the name of your company or your specific service. (See the image below)
 11. Web address of your company
 12. The URL of your production domain as setup in step 5 of the [Getting ready for production](/verify/guides/production)


### PR DESCRIPTION
The word "keys" is confusing as it indicates that there is more than one, and also that it has something to do with private/public keys, which is not the case here.

Suggest to use "credentials" consistently in this article (it is already in use) instead.