### PR TITLE
Removing NemID content: hide from nav

### DIFF
--- a/src/pages/verify/e-ids/danish-nemid.mdx
+++ b/src/pages/verify/e-ids/danish-nemid.mdx
@@ -1,6 +1,6 @@
 ---
 product: verify
-category: eIDs
+category: eIDs(legacy)
 sort: 3
 title: Danish NemID
 subtitle: Learn more about Danish NemID token contents, how to create test users and how to gain access to production.

--- a/src/pages/verify/e-ids/index.mdx
+++ b/src/pages/verify/e-ids/index.mdx
@@ -38,7 +38,7 @@ export const pageQuery = gatsbyGraphql`
   }
 `;
 
-Criipto Verify supports authentication via a number of eIDs
+Criipto Verify supports authentication via a number of eIDs.
 
 Select any individual eID from the list below to see JWT/token details, how to find/create test users and how to order a specific eID for production.
 

--- a/src/pages/verify/e-ids/norwegian-bankid.mdx
+++ b/src/pages/verify/e-ids/norwegian-bankid.mdx
@@ -212,7 +212,7 @@ To start accepting real users with Norwegian BankID, you must first request your
 In order to apply for the BankID client credentials for a company you must meet the basic requirements:
 
 - Your company must be a customer of a Norwegian Bank. Most banks in Norway are part of the BankID network.
-- The person that will sign the contract must be in possession of one of these personal eIDs: Norwegian BankID, Swedish BankID, or Danish NemID
+- The person that will sign the contract must be in possession of one of these personal eIDs: Norwegian BankID, Swedish BankID, or Danish MitID.
 - You must have completed step 5 in the [Getting ready for production](/verify/guides/production) guide. You will need the production domain to complete the order for your client credentials.
 
 </Highlight>

--- a/src/pages/verify/getting-started/basics.mdx
+++ b/src/pages/verify/getting-started/basics.mdx
@@ -21,7 +21,7 @@ This article introduces the following   core concepts of Criipto: **Tenants**, *
 
 </Highlight>
 
-For illustration purposes, we will use a fictitious company named `Secure Insurance` that wants to use Criipto for authentication. They have both a web and a mobile application, and they want their users to be able to log in with Swedish BankID and Danish NemID.
+For illustration purposes, we will use a fictitious company named `Secure Insurance` that wants to use Criipto for authentication. They have both a web and a mobile application, and they want their users to be able to log in with Swedish BankID and Danish MitID.
 
 ## Tenants
 
@@ -79,7 +79,7 @@ In our example, `Secure Insurance` has two apps: a web app (running on a server)
 
 Now that you have set up your **Applications**, you are ready to configure how your users will login. 
 
-Criipto sits between your app and the Identity Sources that authenticate your users (such as Swedish BankID and Danish NemID). Through this abstraction, Criipto keeps your app isolated from any changes of the provider's implementation.
+Criipto sits between your app and the Identity Sources that authenticate your users (such as Swedish BankID and Danish MitID). Through this abstraction, Criipto keeps your app isolated from any changes of the provider's implementation.
 
 Each Identity Source can be shared among multiple applications. You may use all the available Identity Sources for all your applications.
 

--- a/src/pages/verify/getting-started/overview.mdx
+++ b/src/pages/verify/getting-started/overview.mdx
@@ -12,7 +12,7 @@ Criipto Verify provides eID authentication as a service.
 
 <Highlight icon="file-lines">
 
-  An **eID** is a special kind of online identity that is tied to a *natural person*. A natural person in relation to eID is a living, individual human being. Examples of eIDs are Danish NemID, Swedish BankID, and Dutch DigiD.
+  An **eID** is a special kind of online identity that is tied to a *natural person*. A natural person in relation to eID is a living, individual human being. Examples of eIDs are Danish MitID, Swedish BankID, and Dutch DigiD.
 
   An eID may be used for authentication and in most cases also for digitally signing legal documents.
 

--- a/src/pages/verify/getting-started/token-contents.mdx
+++ b/src/pages/verify/getting-started/token-contents.mdx
@@ -80,6 +80,23 @@ The `socialno` field is the social security number.
 
 ## Denmark
 
+### MitID
+```json
+{
+  "identityscheme": "dkmitid",
+  "nameidentifier": "0f9960a0d28d4353a3e2ea07f8ffa185",
+  "sub": "{0f9960a0-d28d-4353-a3e2-ea07f8ffa185}",
+  "streetaddress": "Ny testvej 15 7\n2200 København N\nDenmark",
+  "uuid": "74ffcd31-fbaf-4c33-bdac-169f25c1e416",
+  "cprNumberIdentifier": "2101270087",
+  "birthdate": "1927-01-21",
+  "age": "93",
+  "name": "Ditlev Von Testesen",
+  "country": "DK"
+}
+```
+The `cprNumberIdentifier` field is the social security number.
+
 ### NemID for citizens (POCES)
 ```json
 {
@@ -153,24 +170,6 @@ The `cprNumberIdentifier` field is the social security number.
 }
 ```
 No social security number in this case, but the combination of `cvrNumberIdentifier` and `ridNumberIdentifier` identifies the legal person corresponding to the login.
-
-### MitID
-```json
-{
-  "identityscheme": "dkmitid",
-  "nameidentifier": "0f9960a0d28d4353a3e2ea07f8ffa185",
-  "sub": "{0f9960a0-d28d-4353-a3e2-ea07f8ffa185}",
-  "streetaddress": "Ny testvej 15 7\n2200 København N\nDenmark",
-  "uuid": "74ffcd31-fbaf-4c33-bdac-169f25c1e416",
-  "cprNumberIdentifier": "2101270087",
-  "birthdate": "1927-01-21",
-  "age": "93",
-  "name": "Ditlev Von Testesen",
-  "country": "DK"
-}
-```
-The `cprNumberIdentifier` field is the social security number.
-
 
 ## Finland
 

--- a/src/pages/verify/guides/choose-language.mdx
+++ b/src/pages/verify/guides/choose-language.mdx
@@ -14,7 +14,7 @@ You can override this per authentication request by specifying a `ui_locales` qu
 
 The actual support for controlling the language varies by eID method
 
-1. Danish NemID: Both keycard-based methods support `da` and `en`. Keyfile is only available in danish.
+1. Danish MitID: `da` and `en` supported. 
 2. Norwegian BankID: `nb` and `en` supported.
 3. Norwegian Vipps Login: Language is controlled by user in the app.
 4. Swedish BankID: `sv` and `en` supported.

--- a/src/pages/verify/guides/prefilled-fields.mdx
+++ b/src/pages/verify/guides/prefilled-fields.mdx
@@ -11,20 +11,20 @@ export default Layout;
 
 In some login flows, user-specific data other than actual login details are needed to complete the authentication. 
 
-Examples include the CPR number in Denmark for personal NemID and SSN ("personnummer") in Sweden for BankID on another device.
+Examples include the CPR number in Denmark for personal MitID and SSN ("personnummer") in Sweden for BankID on another device.
 
 By default the user is prompted for this data when needed, but if you would like to avoid these dialogs, you can specify the values up-front in the request for authentication, via the `login_hint` query parameter. This works for both OpenID Connect and WS-Federation.
 
 The actual support for controlling the input data varies by eID method:
 
-1. Danish NemID: Use `login_hint=sub:<CPR>` where `<CPR>` has the format `DDMMYYXXXX`
+1. Danish MitID: Use `login_hint=sub:<CPR>` where `<CPR>` has the format `DDMMYYXXXX`
 2. Swedish BankID: Use `login_hint=sub:<SSN>` where `<SSN>` has the format `YYYYMMDDXXXX`
 3. Norwegian BankID Mobile: Use `login_hint=BIM:<PHONENUMBER>:<BIRTHDATE>` where `<PHONENUMBER>` has 8 digits and `<BIRTHDATE>` has the format `DDMMYY`
 4. Norwegian BankID Kodebrikke: Use `login_hint=BID:<SSN>` where `<SSN>` has the format `DDMMYYXXXXX`
 
 <Highlight icon="file-lines">
 
-Note that you should not include the angle brackets, so for example a Danish NemID prefilled CPR 
+Note that you should not include the angle brackets, so for example a Danish MitID prefilled CPR 
 would be passed like this: `login_hint=sub:2201891234`.
 
 </Highlight>

--- a/src/pages/verify/guides/production.mdx
+++ b/src/pages/verify/guides/production.mdx
@@ -23,4 +23,4 @@ Follow these steps to get ready for production:
     - The Client ID must be unique; it cannot be the same as any of your other applications
 6. Configure your production application with the new domain, Client ID, and Client secret. 
 
-Once you have been through these steps, you are ready to start using real Swedish BankID, Danish NemID, and others in your production application.
+Once you have been through these steps, you are ready to start using real Swedish BankID, Danish MitID, and others in your production application.

--- a/src/pages/verify/integrations/javascript.mdx
+++ b/src/pages/verify/integrations/javascript.mdx
@@ -3,7 +3,7 @@ product: verify
 category: Integrations
 sort: 0
 title: JavaScript
-subtitle: Accept MitID, NemID, Swedish BankID, Norwegian BankID and more eID logins in your JavaScript application with @criipto/auth-js.
+subtitle: Accept Danish MitID, Swedish BankID, Norwegian BankID and more eID logins in your JavaScript application with @criipto/auth-js.
 ---
 
 import Layout from '../../../layouts/mdx';
@@ -123,7 +123,7 @@ Will open a popup window to authenticate the user.
           width: 300,
           height: 400,
           redirectUri: 'http://localhost:8000/example/index.html',
-          acrValues: 'urn:grn:authn:dk:nemid:poces',
+          acrValues: 'urn:grn:authn:dk:mitid:substantial',
         })
         .then((result) => {
           console.log(result, result.id_token, result.claims);

--- a/src/pages/verify/integrations/react-native-expo.mdx
+++ b/src/pages/verify/integrations/react-native-expo.mdx
@@ -3,7 +3,7 @@ product: verify
 category: Integrations
 sort: 1
 title: Expo (React Native)
-subtitle: Accept MitID, NemID, Swedish BankID, Norwegian BankID and more eID logins in your Expo (React Native) app with @criipto/verify-expo.
+subtitle: Accept Danish MitID, Swedish BankID, Norwegian BankID and more eID logins in your Expo (React Native) app with @criipto/verify-expo.
 ---
 
 import Layout from '../../../layouts/mdx';

--- a/src/pages/verify/integrations/react.mdx
+++ b/src/pages/verify/integrations/react.mdx
@@ -3,7 +3,7 @@ product: verify
 category: Integrations
 sort: 0
 title: React
-subtitle: Accept MitID, NemID, Swedish BankID, Norwegian BankID and more eID logins in your React app with @criipto/verify-react.
+subtitle: Accept Danish MitID, Swedish BankID, Norwegian BankID and more eID logins in your React app with @criipto/verify-react.
 ---
 import Layout from '../../../layouts/mdx';
 export default Layout;

--- a/src/pages/verify/integrations/vuejs.mdx
+++ b/src/pages/verify/integrations/vuejs.mdx
@@ -3,7 +3,7 @@ product: verify
 category: Integrations
 sort: 0
 title: Vue.js
-subtitle: Accept MitID, NemID, Swedish BankID, Norwegian BankID and more eID logins in your Vue.js application with @criipto/auth-js.
+subtitle: Accept Danish MitID, Swedish BankID, Norwegian BankID and more eID logins in your Vue.js application with @criipto/auth-js.
 ---
 
 import Layout from '../../../layouts/mdx';
@@ -101,7 +101,7 @@ const loginWithEid = () => {
     width: 300,
     height: 400,
     redirectUri: 'http://localhost:5173',
-    acrValues: 'urn:grn:authn:dk:nemid:poces',
+    acrValues: 'urn:grn:authn:dk:mitid:substantial',
    })
    .then((result) => {
     console.log(result, result.id_token, result.claims);


### PR DESCRIPTION
NemID page is not shown in the navigation (changed category to `eIDs(legacy)`).
Changed NemID to MitID where applicable. 

**Todo:**
- Update URL Builder
- Remove NemID page
- Update token-contents page (remove NemID, use JWTViewer)
- Remove NemID from login-methods