### PR TITLE
BankID NO: add a note about synthetic SSNs

### DIFF
--- a/src/pages/verify/e-ids/norwegian-bankid.mdx
+++ b/src/pages/verify/e-ids/norwegian-bankid.mdx
@@ -53,13 +53,14 @@ Two types of Norwegian BankID are available:
 
 Test users are created through the web page at [https://ra-preprod.bankidnorge.no/#/search/endUser](https://ra-preprod.bankidnorge.no/#/search/endUser).
 
-1. Go to the ["TEST NUMBER GENERATOR"](https://ra-preprod.bankidnorge.no/#/generate) to generate a random, valid SSN
-2. It now says "Could not find any bankIDs for ..."
-3. Fill out the first name, last name, and BankID friendly name
-4. Click "Order" to initiate the process
-5. Click the pencil icon and add a phone number and an email that you want to associate with the test user  
+1. Go to the ["TEST NUMBER GENERATOR"](https://ra-preprod.bankidnorge.no/#/generate) to generate a random, valid SSN.  
+_If you want to test [BankID Biometric](/verify/e-ids/norwegian-bankid/#testing-bankid-biometric), please make sure that the "Synthetic" checkbox is unchecked before generating a new number. BankID Biometric app does not currently support synthetic SSN numbers, so you won't be able to use them for testing._
+2. It now says "Could not find any bankIDs for ...".
+3. Fill out the first name, last name, and BankID friendly name.
+4. Click "Order" to initiate the process.
+5. Click the pencil icon and add a phone number and an email that you want to associate with the test user.  
 _You can use any values that match the correct email and phone number formats (note that the number of digits will differ per country). Random values are acceptable as you'll be able to access the one-time codes via URLs, as shown in steps 5 and 11 of the [Testing BankID Biometric section](/verify/e-ids/norwegian-bankid/#testing-bankid-biometric)._
-6. Once the process is complete, you will have a test user. User name is the generated SSN, one time password (OTP) is always "otp", and password is always "qwer1234"
+6. Once the process is complete, you will have a test user. User name is the generated SSN, one time password (OTP) is always "otp", and password is always "qwer1234".
 
 <Highlight icon="info">
 


### PR DESCRIPTION
The Biometrics app doesn't have support for synthetic SSNs. 
So when generating a test user, the "Synthetic" box should be unchecked. 