### PR TITLE
Fix react integration documentation for criipto verify: Add missing return statements and remove surpurflous else/else-if statements

### DIFF
--- a/src/pages/verify/integrations/react.mdx
+++ b/src/pages/verify/integrations/react.mdx
@@ -64,7 +64,9 @@ export default function App() {
         {JSON.stringify(result.id_token, null, 2)}
       </pre>
     )
-  } else {
+  }
+
+  return (
     <React.Fragment>
       {result?.error ? (
         <p>
@@ -73,7 +75,7 @@ export default function App() {
       ) : null}
       <button onClick={() => loginWithRedirect()}>Login</button>
     </React.Fragment>
-  }
+  );
 }
 ```
 
@@ -95,7 +97,9 @@ export default function App() {
         {JSON.stringify(result.id_token, null, 2)}
       </pre>
     )
-  } else {
+  }
+
+  return (
     <React.Fragment>
       {result?.error ? (
         <p>
@@ -104,7 +108,7 @@ export default function App() {
       ) : null}
       <AuthMethodSelector />
     </React.Fragment>
-  }
+  );
 }
 ```
 
@@ -150,13 +154,16 @@ export default function App() {
   if (isLoading) {
     return <div>Loading</div>
   }
-  else if (claims) {
+
+  if (claims) {
     return (
       <pre>
         {JSON.stringify(claims, null, 2)}
       </pre>
     )
-  } else {
+  }
+
+  return (
     <React.Fragment>
       {error ? (
         <p>
@@ -165,6 +172,6 @@ export default function App() {
       ) : null}
       <AuthMethodSelector />
     </React.Fragment>
-  }
+  );
 }
 ```

--- a/src/pages/verify/integrations/react.mdx
+++ b/src/pages/verify/integrations/react.mdx
@@ -70,7 +70,7 @@ export default function App() {
     <React.Fragment>
       {result?.error ? (
         <p>
-          An error occured: {result.error} ({result.error_description}). Please try again:
+          An error occurred: {result.error} ({result.error_description}). Please try again:
         </p>
       ) : null}
       <button onClick={() => loginWithRedirect()}>Login</button>
@@ -103,7 +103,7 @@ export default function App() {
     <React.Fragment>
       {result?.error ? (
         <p>
-          An error occured: {result.error} ({result.error_description}). Please try again:
+          An error occurred: {result.error} ({result.error_description}). Please try again:
         </p>
       ) : null}
       <AuthMethodSelector />
@@ -167,7 +167,7 @@ export default function App() {
     <React.Fragment>
       {error ? (
         <p>
-          An error occured: {error.error} ({error.error_description}). Please try again:
+          An error occurred: {error.error} ({error.error_description}). Please try again:
         </p>
       ) : null}
       <AuthMethodSelector />


### PR DESCRIPTION
Porting over the same fixes from the readme of https://github.com/criipto/criipto-verify-react/pull/32 to the docs website