### PR TITLE
Add OIDC best security practices guide

### DIFF
--- a/src/pages/verify/e-ids/swedish-bankid.mdx
+++ b/src/pages/verify/e-ids/swedish-bankid.mdx
@@ -46,7 +46,7 @@ _The full content of `evidence` and `ocspResponse` is omitted for brevity._
 
 When included in the payload, `evidence` and `ocspResponse` claims will significantly increase the size of the JWT token, potentially causing it to exceed the size limitations of an HTTP header. The bloated JWTs would thus become unusable as Bearer tokens for accessing APIs.
 
-To address this concern, consider changing the <a href="https://openid.net/specs/oauth-v2-multiple-response-types-1_0.html" target="_blank">response type</a> in your [authorization request](/verify/getting-started/oidc-intro/#example-authentication-url) to `response_type=code id_token`.
+To address this concern, consider changing the <a href="https://openid.net/specs/oauth-v2-multiple-response-types-1_0.html" target="_blank">response type</a> in your [authorization request](/verify/getting-started/oidc-intro/#example-authorization-url) to `response_type=code id_token`.
 
 In this case, a more compact ID Token with only essential claims will be issued from the Token endpoint. The client can subsequently fetch all data about the user from the Userinfo endpoint.
 

--- a/src/pages/verify/getting-started/basics.mdx
+++ b/src/pages/verify/getting-started/basics.mdx
@@ -11,7 +11,7 @@ export default Layout;
 
 This document explains some of the basic terminology we use at Criipto, and we try to relate these terms to concepts you are already familiar with. 
 
-This article introduces the following   core concepts of Criipto: **Tenants**, **Domains**, **Applications**, and **Identity Sources**. Each is explained in the following.
+This article introduces the following core concepts of Criipto: **[Tenants](/verify/getting-started/basics/#tenants)**, **[Domains](/verify/getting-started/basics/#domains)**, **[Applications](/verify/getting-started/basics/#applications)**, and **[Identity Sources](/verify/getting-started/basics/#identity-sources)**.
 
 <Highlight icon="file-lines">
 
@@ -27,7 +27,7 @@ For illustration purposes, we will use a fictitious company named `Secure Insura
 
 If you haven't already [signed up](https://criipto.com/signup) for a Criipto account, feel free - it's free. 
 
-When you signup for the first time you will be asked to create your first tenant and your first _domain_ along with it. In Criipto, a tenant is the **logical isolation unit** that isolates you and your data from other Criipto tenants. The term describes a software architecture where a single instance of the software serves multiple tenants. No tenant can access the instance of another tenant, even though the software may be running on the same machine.
+When you sign up for the first time, you will be asked to create your first tenant and your first _domain_ along with it. In Criipto, a tenant is the **logical isolation unit** that isolates you and your data from other Criipto tenants. The term describes a software architecture where a single instance of the software serves multiple tenants. No tenant can access the instance of another tenant, even though the software may be running on the same machine.
 
 Tenant characteristics:
 
@@ -45,7 +45,7 @@ A domain in Criipto Verify is the DNS domain on which you call our service to pe
 
 <Highlight icon="info">
 
-  Domains are registered for either test or production and as such determines whether you can use test eID accounts or real, live eID accounts. 
+  Domains are registered for either test or production and as such determine whether you can use test eID accounts or real, live eID accounts. 
 
   As such, **the domain is the key distinction between test and production.**
 
@@ -53,7 +53,7 @@ A domain in Criipto Verify is the DNS domain on which you call our service to pe
 
 ### Bring your own domain
 
-For development and testing it is usually sufficient to just use the preconfigured `criipto.id` top-level domain, but for production you may wish to map a domain of your own, such as `login.secure-insurance.com`, to point to Criipto Verify. In some scenarios this is required for technical reasons, but you should also keep in mind the perception of your users. They may feel uncomfortable being taken to a third party domain to login. If instead you have mapped your own domain, your users may feel safer as they are being kept in the realm of your company and application.
+For development and testing it is usually sufficient to just use the preconfigured `criipto.id` top-level domain, but for production you may wish to map a domain of your own, such as `login.secure-insurance.com`, to point to Criipto Verify. In some scenarios this is required for technical reasons, but you should also keep in mind the perception of your users. They may feel uncomfortable being taken to a third-party domain to log in. If instead you have mapped your own domain, your users may feel safer as they are being kept in the realm of your company and application.
 
 If you choose to set up your own domain for production you must have access to your company's _DNS setup_ and be able to acquire a so-called _SSL certificate_ which must be uploaded to the Criipto Verify service (after setting up your DNS record).
 
@@ -77,9 +77,9 @@ In our example, `Secure Insurance` has two apps: a web app (running on a server)
 
 ## Identity Sources
 
-Now that you have set up your **Applications**, you are ready to configure how your users will login. 
+Now that you have set up your **Applications**, you are ready to configure how your users will log in. 
 
-Criipto sits between your app and the Identity Sources that authenticate your users (such as Swedish BankID and Danish MitID). Through this abstraction, Criipto keeps your app isolated from any changes of the provider's implementation.
+Criipto sits between your app and the Identity Sources that authenticate your users (such as Swedish BankID and Danish MitID). Through this abstraction, Criipto keeps your app isolated from any changes in the provider's implementation.
 
 Each Identity Source can be shared among multiple applications. You may use all the available Identity Sources for all your applications.
 
@@ -87,7 +87,7 @@ Each Identity Source can be shared among multiple applications. You may use all 
 
   Identity sources are already configured for test when you create a tenant. To be able to use an Identity Source in production you will - in most cases - have to enter into some sort of formal agreement with the provider of the particular type of eID.
 
-  In most cases this is handled through the intermediary of Criipto, although in some cases you will also have to set up direct agreements (in countries such as Denmark and the Netherlands).
+  In most cases, this is handled through the intermediary of Criipto, although in some cases you will also have to set up direct agreements (in countries such as Denmark and the Netherlands).
 
   More detail on the formalities and process can be found in the section about [eIDs](/verify/e-ids/).
 
@@ -95,4 +95,4 @@ Each Identity Source can be shared among multiple applications. You may use all 
 
 ## Where to go from here
 
-In this article you have familiarized yourself with several core concepts of Criipto. If you wish to learn more about the next steps in setting up Criipto, you can read more in the rest of the documentation.
+This section introduced several core concepts of Criipto. Next, we recommend learning [how Criipto supports the OpenID Connect protocol](/verify/getting-started/oidc-intro/) and reviewing [best security practices for implementing OpenID Connect authentication](/verify/getting-started/best-security-practices/) in client applications.

--- a/src/pages/verify/getting-started/best-security-practices.mdx
+++ b/src/pages/verify/getting-started/best-security-practices.mdx
@@ -1,0 +1,93 @@
+---
+product: verify
+category: Getting Started
+sort: 3
+title: OpenID Connect best security practices
+subtitle: Learn about key security guidelines for implementing basic OpenID Connect authentication in client applications.
+---
+
+import Layout from '../../../layouts/mdx';
+
+export default Layout;
+
+In OpenID Connect(OIDC) authentication flows, there are two main roles:
+
+1. **Authorization Server (OpenID Provider)**: the server that authenticates the user and issues ID tokens and access tokens. It handles user authentication and returns the user’s identity information to the client application.
+2. **Client Application**: the application requesting authentication on behalf of the end user.
+
+Criipto Verify is an OpenID Provider, handling most of the process. However, it's important for developers of client applications to also follow security best practices.
+
+## Authorization Code Flow
+
+The most secure method of performing OIDC authentication is the [Authorization Code Flow](/verify/getting-started/oidc-intro/#authenticate-with-back-channel-authorization-code-flow), or its extended version — [Authorization Code Flow with PKCE](http://localhost:8000/verify/getting-started/oidc-intro/#authenticate-with-pkce). 
+
+In the Authorization Code Flow, the client application exchanges an authorization code for tokens at the token endpoint. When using Criipto Verify for eID authentication: After the end user successfully logs in with their [eID](/verify/e-ids) and is redirected back to the client application through the redirect URL, the client application retrieves the authorization code from the URL. The client application then uses this code to request an ID token from Criipto Verify (see [code for token exchange](/verify/getting-started/oidc-intro/#exchange-the-code-for-a-token)).
+
+The Authorization Code Flow enhances security by mitigating replay attempts by attackers (when an attacker tries to reuse a valid intercepted token) and generally reduces the attack surface since ID tokens are not exposed in URLs.
+
+**Best practice:**
+
+- Public clients — such as single-page applications and native applications — must use the **PKCE flow** to prevent misuse of authorization codes.
+- Confidential clients — such as traditional server-based web applications — must use the **Authorization Code Flow**.
+- Confidential clients implementing the Authorization Code Flow should take additional precautions, such as using the `nonce` parameter and the respective claim in the `id_token`, or one-time tokens carried in the `state` parameter.
+- For use cases where authentication is initiated on one device but completed on another (e.g., a call center agent starts the authentication process for the end user), the back-channel [CIBA flow](/verify/getting-started/oidc-intro/#authenticate-with-ciba) is the right choice.
+- The Implicit Flow is obsolete and [should never be used](/verify/getting-started/best-security-practices/#avoid-implicit-flow).
+
+## The nonce parameter
+
+`nonce` is used to associate an ID token to the specific authentication request and user session.
+
+The client application should bind `nonce` to the user agent session and send it with the initial request to the OpenID Provider. The binding is done using HTTPOnly, Secure cookies, and preferably with a server-side encrypted value for the `nonce` (using authenticated encryption). The OpenID Provider puts the received `nonce` value into the `id_token` that is issued as part of the [code exchange](/verify/getting-started/oidc-intro/#exchange-the-code-for-a-token) at the token endpoint.
+
+- `nonce` serves as a [token validation](/verify/getting-started/best-security-practices/#always-validating-jwts) parameter. If an attacker injects an authorization code in the authorization response, the `nonce` value in the client session and the `nonce` value in the `id_token` received from the token endpoint will not match, and the attack will be detected. 
+- `nonce` also helps protect against an attacker potentially intercepting a valid [`state` parameter](/verify/getting-started/best-security-practices/#the-state-parameter), but then providing a `code` value tied to a different session. This could be a concern for public clients, and, in theory, in some confidential client scenarios.
+
+**Best practice:** It is recommended to always include a `nonce` in your [authorize URLs](/verify/guides/authorize-url-builder/). Your application should then validate the `nonce` in the received `id_token`, and not use any issued tokens until this check has succeeded.
+
+## The state parameter
+
+The `state` parameter helps prevent Cross-Site Request Forgery (CSRF) attacks by maintaining state between the client application and the authorization server. The client application passes a random value, also known as a CSRF Token, in the `state` parameter, that links the request to the redirect URL to the client session.
+
+When the user has been authenticated, the authorization server redirects the user back to the client application’s redirect URL, including the `state` parameter in the URL. For example:
+
+`https://your-app.com/callback?code=authorization-code&state=unique-state-value`
+
+The `state` parameter allows the client application to verify that the authorization response is genuine and was sent by the authorization server in response to the original authentication request.
+
+**Best practice:** Always generate a unique, random `state` value for each authorization request and validate it when the response is received.
+
+## Always validating JWTs
+
+Upon successful user authentication, Criipto Verify will issue an **[ID token](/verify/getting-started/token-contents/)** to the client application. `id_token` contains user authentication information in the form of a JSON Web Token (JWT). 
+However, receiving a JWT is not enough - your application must also [validate it](/verify/getting-started/oidc-intro/#validate-the-jwt). Without validation, there’s no guarantee that the token hasn’t been tampered with or forged.
+
+*Note: `id_token` must be validated, even if using the `/userInfo` endpoint for personal data.*
+
+**Best practice:** Always delegate token validation to trusted libraries like <a href='https://github.com/panva/jose' target="_blank">jose</a> or choose one of [Criipto's integrations](/verify/integrations). Libraries like these handle all the complexities involved in checking JWT signatures, token expiration, etc. Manual validation should be avoided. 
+More information on how JWT validation works is available in our <a href='https://www.criipto.com/blog/jwt-validation-guide' target="_blank">JWT validation guide</a>.
+
+## Client authentication
+
+For client authentication, it is recommended to use asymmetric cryptography, such as [Private Key JWTs](/verify/guides/privatekey-jwt/). This provides stronger security compared to symmetric key methods.
+
+When using asymmetric cryptography, authorization servers do not need to store sensitive symmetric keys, reducing the risk of key leakage. Additionally, key rotation is simplified because you can provide a JWT keys set in a URL, allowing Criipto Verify to dynamically fetch the updated keys.
+
+**Best practice:** Use Private Key JWTs for client authentication to enhance security and simplify key management.
+
+## Avoid Implicit Flow
+
+The Implicit Flow has been deprecated and is considered insecure due to its vulnerability to token leakage and token replay attacks. Client applications should not use the Implicit Flow or any other method that causes the authorization server to issue tokens directly in the authorization response (such as `response_type=id_token`).
+
+Tokens in the Implicit Flow are exposed in the URL fragment (`response_mode=fragment`), making them vulnerable to interception and mishandling. While `response_mode=fragment` is convenient and easy to use during development and testing, it is insecure for production applications for several reasons:
+
+- Tokens in a URL fragment can be exposed to browser history, referral headers, and intermediaries.
+- Browser components or extensions may access the fragment, increasing the risk of interception or token leakage.
+- Some modern browsers restrict or block the use of URL fragments in certain scenarios, which 70causes compatibility issues. 
+
+### Use response_mode=query
+
+For improved security, use `response_mode=query`, which returns authorization parameters in the query string of the redirect URL. This approach is more secure and is the default `response_mode` for the Authorization Code Flow and PKCE.
+
+## More information
+
+For detailed information on security requirements and other recommendations for clients and servers implementing OAuth 2.0 and OpenID Connect, check <a href='https://datatracker.ietf.org/doc/html/draft-ietf-oauth-security-topics' target="_blank">OAuth 2.0 Security Best Current Practice</a>.

--- a/src/pages/verify/getting-started/best-security-practices.mdx
+++ b/src/pages/verify/getting-started/best-security-practices.mdx
@@ -15,11 +15,11 @@ In OpenID Connect(OIDC) authentication flows, there are two main roles:
 1. **Authorization Server (OpenID Provider)**: the server that authenticates the user and issues ID tokens and access tokens. It handles user authentication and returns the user’s identity information to the client application.
 2. **Client Application**: the application requesting authentication on behalf of the end user.
 
-Criipto Verify is an OpenID Provider, handling most of the process. However, it's important for developers of client applications to also follow security best practices.
+Criipto Verify is an OpenID Provider, handling most of the process. However, it is important for developers of client applications to also follow security best practices.
 
 ## Authorization Code Flow
 
-The most secure method of performing OIDC authentication is the [Authorization Code Flow](/verify/getting-started/oidc-intro/#authenticate-with-back-channel-authorization-code-flow), or its extended version — [Authorization Code Flow with PKCE](http://localhost:8000/verify/getting-started/oidc-intro/#authenticate-with-pkce). 
+The most secure method of performing OIDC authentication is the [Authorization Code Flow](/verify/getting-started/oidc-intro/#authenticate-with-back-channel-authorization-code-flow), or its extended version — [Authorization Code Flow with PKCE](/verify/getting-started/oidc-intro/#authenticate-with-pkce). 
 
 In the Authorization Code Flow, the client application exchanges an authorization code for tokens at the token endpoint. When using Criipto Verify for eID authentication: After the end user successfully logs in with their [eID](/verify/e-ids) and is redirected back to the client application through the redirect URL, the client application retrieves the authorization code from the URL. The client application then uses this code to request an ID token from Criipto Verify (see [code for token exchange](/verify/getting-started/oidc-intro/#exchange-the-code-for-a-token)).
 
@@ -28,8 +28,9 @@ The Authorization Code Flow enhances security by mitigating replay attempts by a
 **Best practice:**
 
 - Public clients — such as single-page applications and native applications — must use the **PKCE flow** to prevent misuse of authorization codes.
-- Confidential clients — such as traditional server-based web applications — must use the **Authorization Code Flow**.
-- Confidential clients implementing the Authorization Code Flow should take additional precautions, such as using the `nonce` parameter and the respective claim in the `id_token`, or one-time tokens carried in the `state` parameter.
+- Confidential clients — such as traditional server-based web applications – are encouraged to use the **PKCE flow** as well. This is a recommended approach, since **PKCE** provides strong protection against misuse and injection of authorization codes, making it a more secure option.
+- Alternatively, confidential clients can implement the **Authorization Code Flow**.
+- Confidential clients implementing the **Authorization Code Flow** (without **PKCE**) should take additional precautions, such as using the `nonce` parameter and the respective claim in the `id_token`, and one-time tokens carried in the `state` parameter.
 - For use cases where authentication is initiated on one device but completed on another (e.g., a call center agent starts the authentication process for the end user), the back-channel [CIBA flow](/verify/getting-started/oidc-intro/#authenticate-with-ciba) is the right choice.
 - The Implicit Flow is obsolete and [should not be used in production applications](/verify/getting-started/best-security-practices/#avoid-implicit-flow).
 

--- a/src/pages/verify/getting-started/best-security-practices.mdx
+++ b/src/pages/verify/getting-started/best-security-practices.mdx
@@ -31,28 +31,32 @@ The Authorization Code Flow enhances security by mitigating replay attempts by a
 - Confidential clients — such as traditional server-based web applications — must use the **Authorization Code Flow**.
 - Confidential clients implementing the Authorization Code Flow should take additional precautions, such as using the `nonce` parameter and the respective claim in the `id_token`, or one-time tokens carried in the `state` parameter.
 - For use cases where authentication is initiated on one device but completed on another (e.g., a call center agent starts the authentication process for the end user), the back-channel [CIBA flow](/verify/getting-started/oidc-intro/#authenticate-with-ciba) is the right choice.
-- The Implicit Flow is obsolete and [should never be used](/verify/getting-started/best-security-practices/#avoid-implicit-flow).
+- The Implicit Flow is obsolete and [should not be used in production applications](/verify/getting-started/best-security-practices/#avoid-implicit-flow).
 
 ## The nonce parameter
 
-`nonce` is used to associate an ID token to the specific authentication request and user session.
+`nonce` is used to associate an ID token to the specific authorization request and user session.
 
-The client application should bind `nonce` to the user agent session and send it with the initial request to the OpenID Provider. The binding is done using HTTPOnly, Secure cookies, and preferably with a server-side encrypted value for the `nonce` (using authenticated encryption). The OpenID Provider puts the received `nonce` value into the `id_token` that is issued as part of the [code exchange](/verify/getting-started/oidc-intro/#exchange-the-code-for-a-token) at the token endpoint.
+The client application should bind `nonce` to the user agent session and send it with the initial [authorization request](/verify/getting-started/oidc-intro/#example-authorization-url) to the OpenID Provider. The binding is done using HTTPOnly, Secure cookies, and preferably with a server-side encrypted value for the `nonce` (using authenticated encryption). 
+The OpenID Provider puts the received `nonce` value into the `id_token` that is issued as part of the [code exchange](/verify/getting-started/oidc-intro/#exchange-the-code-for-a-token) at the token endpoint.
 
 - `nonce` serves as a [token validation](/verify/getting-started/best-security-practices/#always-validating-jwts) parameter. If an attacker injects an authorization code in the authorization response, the `nonce` value in the client session and the `nonce` value in the `id_token` received from the token endpoint will not match, and the attack will be detected. 
 - `nonce` also helps protect against an attacker potentially intercepting a valid [`state` parameter](/verify/getting-started/best-security-practices/#the-state-parameter), but then providing a `code` value tied to a different session. This could be a concern for public clients, and, in theory, in some confidential client scenarios.
 
-**Best practice:** It is recommended to always include a `nonce` in your [authorize URLs](/verify/guides/authorize-url-builder/). Your application should then validate the `nonce` in the received `id_token`, and not use any issued tokens until this check has succeeded.
+**Best practice:** For confidential clients implementing the Authorization Code Flow, it is strongly recommended to always include a `nonce` parameter in authorization requests to protect against misuse of authorization codes. 
+The client application should then validate the `nonce` in the received `id_token`, and not use any issued tokens until this check has succeeded. 
+_For public clients using the PKCE flow, the `nonce` parameter can also provide an additional layer of security. However, it should only be used in addition to PKCE, not as a substitute for it._
 
 ## The state parameter
 
-The `state` parameter helps prevent Cross-Site Request Forgery (CSRF) attacks by maintaining state between the client application and the authorization server. The client application passes a random value, also known as a CSRF Token, in the `state` parameter, that links the request to the redirect URL to the client session.
+The `state` parameter helps prevent Cross-Site Request Forgery (CSRF) attacks by maintaining state between the client application and the authorization server. 
 
-When the user has been authenticated, the authorization server redirects the user back to the client application’s redirect URL, including the `state` parameter in the URL. For example:
+When initiating an [authorization request]((/verify/getting-started/oidc-intro/#example-authorization-url)), the client application generates a random value and includes it in the `state` parameter. 
+This random value links the request to the redirect URL to the client session. Once the user is authenticated, the authorization server redirects the user back to the client application's redirect URL, including the same `state` value in the URL. For example: `https://your-app.com/callback?code=authorization-code&state=unique-state-value`
 
-`https://your-app.com/callback?code=authorization-code&state=unique-state-value`
+Similarly, if the `state` parameter was included in the authorization request, the error responses from the authorization server will also contain the `state` parameter, providing protection against attacker-forged error responses. 
 
-The `state` parameter allows the client application to verify that the authorization response is genuine and was sent by the authorization server in response to the original authentication request.
+Overall, the `state` parameter allows the client application to verify that the authorization response is genuine and was sent by the authorization server in response to the original authorization request.
 
 **Best practice:** Always generate a unique, random `state` value for each authorization request and validate it when the response is received.
 

--- a/src/pages/verify/getting-started/best-security-practices.mdx
+++ b/src/pages/verify/getting-started/best-security-practices.mdx
@@ -86,7 +86,7 @@ Tokens in the Implicit Flow are exposed in the URL fragment (`response_mode=frag
 
 - Tokens in a URL fragment can be exposed to browser history, referral headers, and intermediaries.
 - Browser components or extensions may access the fragment, increasing the risk of interception or token leakage.
-- Some modern browsers restrict or block the use of URL fragments in certain scenarios, which 70causes compatibility issues. 
+- Some modern browsers restrict or block the use of URL fragments in certain scenarios, which causes compatibility issues. 
 
 ### Use response_mode=query
 

--- a/src/pages/verify/getting-started/oidc-intro.mdx
+++ b/src/pages/verify/getting-started/oidc-intro.mdx
@@ -3,7 +3,7 @@ product: verify
 category: Getting Started
 sort: 2
 title: Using OpenID Connect
-subtitle: Learn how Criipto supports the OpenID Connect protocol
+subtitle: Learn how Criipto supports the OpenID Connect protocol.
 ---
 import Layout from '../../../layouts/mdx';
 
@@ -11,40 +11,41 @@ export default Layout;
 
 ## Using OpenID Connect to integrate with Criipto Verify
 
-Criipto Verify is integrated through the authentication API which follows the OpenID Connect and OAuth2 specifications. 
+Criipto Verify is an OpenID Provider. It is integrated through the authentication API which follows the <a href='https://openid.net/specs/openid-connect-core-1_0.html' target="_blank">OpenID Connect</a> and <a href='https://datatracker.ietf.org/doc/html/rfc6749' target="_blank">OAuth 2.0</a> specifications.
 
-<Highlight icon="file-lines">
+### Supported OpenID Connect Flows
 
-Criipto Verify is an OpenID Provider. It supports four different OpenID Connect flows: the OAuth2 **authorization code flow**, the **PKCE flow**, the (now deprecated) **implicit flow**, and the **CIBA flow**. 
+The OpenID Connect(OIDC) protocol defines different strategies (flows) to authenticate users. Criipto Verify supports four different OpenID Connect flows:  
 
-**The authorization code flow** is used for traditional server-based web applications, also referred to as _confidential clients_. These applications can securely store a client secret and establish back-channel communication with the Criipto Verify service. This facilitates a secure [code-for-token exchange](#exchange-the-code-for-a-token) during authentication.
+#### [1. The Authorization Code Flow](/verify/getting-started/oidc-intro/#authenticate-with-back-channel-authorization-code-flow)
 
-**The PKCE flow** (pronounced _pixy_) can be used by _public clients_ such as single page applications(SPAs) and native applications that cannot keep a secret. With PKCE flow, a one-time secret is generated and used for the code exchange.
+The Authorization Code Flow is used for traditional server-based web applications, also referred to as _confidential clients_. These applications can securely store a client secret and establish back-channel communication with the Criipto Verify service. This facilitates a secure [code-for-token exchange](#exchange-the-code-for-a-token) during authentication.
 
-The traditional **implicit flow** returns a token directly in the browser. Support for this flow is being discontinued, although it will continue to function on test domains for the foreseeable future for simpler debugging during development.
+#### [2. The PKCE Flow](/verify/getting-started/oidc-intro/#authenticate-with-pkce)
+The PKCE Flow (pronounced _pixy_) can be used by _public clients_ such as single-page applications (SPAs) and native applications that cannot keep a secret. With PKCE, a one-time secret is generated and used for the code exchange.
 
-**The CIBA flow** is designed for use cases where the client application isn't directly operated by the end-user but can trigger the authentication process on their behalf. A canonical example is a call center agent verifying a caller's identity.
+#### [3. The Implicit Flow](/verify/getting-started/oidc-intro/#authenticate-with-implicit-flow)
+The Implicit Flow (now deprecated) returns a token directly in the browser. Support for this flow is being discontinued, although it will continue to function on test domains for the foreseeable future for simpler debugging during development.
 
-*When implementing Criipto Verify, consider your application's architecture and requirements in order to select and implement the appropriate OpenID Connect flow.*
+#### [4. The CIBA flow](/verify/getting-started/oidc-intro/#authenticate-with-ciba)
+The CIBA flow is designed for use cases where the client application isn't directly operated by the end-user but can trigger the authentication process on their behalf. A canonical example is a call center agent verifying a caller's identity.
 
-</Highlight>
-
-The following sections describe the four flows and introduce the parameters to configure the authentication and subsequent user information retrieval.  
+**The choice of the OpenID Connect flow depends on the requirements and architecture of the client application implementing the OIDC authentication.**
 
 <Highlight icon="info">
+The following sections describe the four flows and introduce the parameters to configure the authentication and subsequent user information retrieval.
 
 Please beware that you don't have to go through the below motions manually. Most often it will be handled by configuring an OpenID Connect package on your platform of choice.
 
 </Highlight>
 
-
 ## Authenticate the User
 
-To begin the login flow, you will need to authenticate the user at the identity source indicated in your request.
+To begin the login flow, you will need to authenticate the user at the [identity source](/verify/e-ids) indicated in your request.
 
-To authenticate the user, your app must send the user to the *OAuth2 authorization endpoint* with the appropriate set of parameters.
+To authenticate the user, your app must send the user to the *OAuth2 authorization endpoint (`/oauth2/authorize`)* with the appropriate set of parameters.
 
-You can find the URL for the *OAuth2 authorization endpoint* in the OpenID Connect Discovery Document exposed on your Criipto Verify Domain:
+You can find the URL for the *OAuth2 authorization endpoint* in the OpenID Connect Discovery Document exposed on your [Criipto Verify Domain](/verify/getting-started/basics/#domains):
 
 ```
 GET https://YOUR_SUBDOMAIN.criipto.id/.well-known/openid-configuration
@@ -52,7 +53,7 @@ GET https://YOUR_SUBDOMAIN.criipto.id/.well-known/openid-configuration
 
 The response from this endpoint is a JSON document, with an `authorization_endpoint` property. The corresponding property value is the URL of the *OAuth2 authorization endpoint*.
 
-### Example authentication URL
+### Example authorization URL
 
 The following initiates the authentication through an OAuth2 authorization request:
 
@@ -66,7 +67,7 @@ GET https://YOUR_SUBDOMAIN.criipto.id/oauth2/authorize?
     state=YOUR_STATE
 ```
 
-Note that providing `response_type=code` specifies that you want either the traditional back-channel *authorization code* flow or the *PKCE* flow. If you specify `response_type=id_token` you indicate that you want the *implicit flow*. In the implicit flow you receive the issued token in a query parameter on the return URL.
+Note that providing `response_type=code` specifies that you want either the traditional back-channel *Authorization Code Flow* or the *PKCE Flow*. If you specify `response_type=id_token` you indicate that you want the *Implicit Flow*. In the Implicit Flow, you receive the issued token in a URL fragment on the return URL.
 
 If you want to receive the response in another way you must specify the `response_mode` parameter, see below.
 
@@ -81,12 +82,12 @@ If you want to receive the response in another way you must specify the `respons
 | `redirect_uri`  | The URL to which Criipto will redirect the browser after authentication has been completed. The authorization code and the `id_token` will be available in the `code` and `id_token` URL parameter for the back-channel flow and on a URL query parameter for the front-channel flow. This URL must be pre-registered as a valid callback URL in your application settings.<br /> <br /> **Warning:** Per the [OAuth 2.0 Specification](https://tools.ietf.org/html/rfc6749#section-3.1.2), Criipto removes everything after the hash and does *not* honor any fragments. |
 | `scope`         | For applications configured with a `static` scope strategy, specify `openid`. This gets you the information configured in the management dashboard for each kind of eID (where applicable).  <br />  <br />  For applications configured with a `dynamic` scope strategy, you must specify scope tokens for the types of data you want, in addition to the `openid` scope token. Possible values are described in the individual eID articles.<br /> <br />You can read more about this parameter [here](#the-scope-parameter) |
 | `acr_values`    | Identifies which eID identity service you want to use. You can only specify one value, and it must identify the exact type of identity service, as some countries have, for example, both a mobile and web based service. Possible values can be found in the [authorize request builder](/verify/guides/authorize-url-builder/#auth-methods--acr-values). |
-| `response_mode` | (optional) Specifies how you want your result delivered via the `redirect_uri`: Use `query` to return the `code`/`id_token` as a query parameter, `fragment` to have it delivered on a URL fragment, and finally `form_post` to have it posted back to your `redirect_uri`.  <br />  <br /> Default values are `query` for `response_type=code` and `query` for `response_type=id_token`. |
+| `response_mode` | (optional) Specifies how you want your result delivered via the `redirect_uri`: Use `query` to return the `code`/`id_token` as a query parameter, `fragment` to have it delivered on a URL fragment, and finally `form_post` to have it posted back to your `redirect_uri`.  <br />  <br /> Default values are `query` for `response_type=code` and `fragment` for `response_type=id_token`. |
 | `state`         | (optional but recommended) An opaque arbitrary alphanumeric string your app adds to the initial request that Criipto includes when redirecting back to your application. |
 | `login_hint`    | (optional) Various use cases leverage this parameter. You can read more about them [here](#the-loginhint-parameter).|
 | `prompt`        | (optional) Specifies whether the user will be forced to re-authenticate. Possible values are `none`, `login`, `consent`, and `consent_revoke`. More information is available in our [SSO guide](/verify/guides/sso/#per-request-options) and in our [authorize URL builder](/verify/guides/authorize-url-builder/). |
 
-As an example, your HTML snippet for your authorization URL when adding login to your app might look like:
+When adding login to your application, you will build the authorization URL (also called the [_authorize URL_](/verify/guides/authorize-url-builder/)) and redirect the user to it. An HTML snippet for your authorize URL might look like this:
 
 ```html
 <a href="https://acme-corp.criipto.id/oauth2/authorize?
@@ -102,9 +103,16 @@ As an example, your HTML snippet for your authorization URL when adding login to
 
 You can <a href="https://acme-corp.criipto.id/oauth2/authorize?response_type=id_token&client_id=urn:debug:jwt.io&acr_values=urn:grn:authn:no:bankid&redirect_uri=https://jwt.io&scope=openid&state=etats" target="_blank">try the above URL</a> right now if you have a [test user for Norwegian BankID](/verify/e-ids/norwegian-bankid/#test-users).
 
-For more about how to handle the implicit flow, see below. 
+Your next steps will depend on the [OpenID Connect flow type](/verify/getting-started/oidc-intro/#supported-openid-connect-flows) you're implementing. See the relevant section below for a description of how each flow unfolds:
 
-## Authenticate with back-channel code flow
+- [Authorization Code Flow](/verify/getting-started/oidc-intro/#authenticate-with-back-channel-authorization-code-flow)
+- [PKCE Flow](/verify/getting-started/oidc-intro/#authenticate-with-pkce)
+- [Implicit Flow](/verify/getting-started/oidc-intro/#authenticate-with-implicit-flow)
+- [CIBA](/verify/getting-started/oidc-intro/#authenticate-with-ciba)
+
+After completing the steps specific to your chosen flow, you can proceed to [validating the JWT](/verify/getting-started/oidc-intro/#validate-the-jwt) received from successful authentication.
+
+## Authenticate with back-channel Authorization Code Flow
 
 ### Example request
 
@@ -121,7 +129,7 @@ GET https://YOUR_SUBDOMAIN.criipto.id/oauth2/authorize?
 
 ### Example response
 
-For the code flow, when you used `response_type=code`, you will receive an `HTTP 302` response which redirects your browser to your specified `redirect_uri` with the authorization code included at the end of the URL:
+For the Authorization Code Flow, when you used `response_type=code`, you will receive an `HTTP 302` response which redirects your browser to your specified `redirect_uri` with the authorization code included at the end of the URL:
 
 ```text
 HTTP/1.1 302 Found
@@ -139,7 +147,7 @@ Location: YOUR_RETURN_URL?error=ERROR_CODE&error_description=...&state=YOUR_STAT
 
 ### Exchange the code for a token
 
-For the code flow you will need to exchange the returned code for an actual token. This is done by posting the authorization code received from the previous step to the token endpoint.
+For the Authorization Code Flow, you will need to exchange the returned code for an actual token. This is done by posting the authorization code received from the previous step to the token endpoint.
 
 For PKCE-enabled clients, this exchange is based on a one-time secret created by the OIDC library you use to handle the flow, and the exchange will also be handled by the same library.
 
@@ -192,7 +200,7 @@ GET https://YOUR_SUBDOMAIN.criipto.id/oauth2/authorize?
 
 ### Example response #example-response-pkce
 
-For authentication using code flow, you will receive an `HTTP 302` response which redirects your browser to your specified `redirect_uri` with the authorization code included at the end of the URL:
+You will receive an `HTTP 302` response which redirects your browser to your specified `redirect_uri` with the authorization code included at the end of the URL:
 
 ```text
 HTTP/1.1 302 Found
@@ -208,11 +216,11 @@ Content-Type: application/x-www-form-urlencoded
 grant_type=authorization_code&code=AUTHORIZATION_CODE&client_id=CLIENT_ID&redirect_uri=YOUR_RETURN_URL&code_verifier=YOUR_CODE_VERIFIER
 ```
 
-## Authenticate with implicit flow
+## Authenticate with Implicit Flow
 
-Implicit flow, which returns an `id_token` directly in the browser via the `#` fragment, is supported, but not recommended.
+Implicit Flow, which returns an `id_token` directly in the browser via the `#` fragment, is supported, but not recommended.
 
-[@criipto/auth-js](https://github.com/criipto/criipto-auth.js) supports implicit flow.
+[@criipto/auth-js](https://github.com/criipto/criipto-auth.js) supports Implicit Flow.
 
 ### Example request #example-request-implicit
 
@@ -306,14 +314,15 @@ The token will be issued upon successful user identification:
 }
 ```
 
-## Validate the response
+## Validate the JWT
 
-You can now proceed with validating the returned `JWT` and access the contained end-user information.
-The validation step is required - if you do not validate the signature, you cannot trust the contained end-user information.
-We strongly recommend that you find a battle-hardened library for you specific platfrom to do this heavy lifting.
-Criipto has a list of [integrations](/verify/integrations) and you can find an extensive list of libraries on [jwt.io](https://jwt.io) (scroll down to the `Libraries for Token Signing/Verification` section).
+You can now proceed with validating the `JWT` returned in response and access the [end-user information it contains](/verify/getting-started/token-contents/). 
+The validation step is required; without it, you cannot trust the contained end-user information. 
 
-You can find more informaiton about JWT validation (including a few code samples) <a href="https://www.criipto.com/blog/jwt-validation-guide" target="_blank">in our blogpost</a>. 
+We strongly recommend that you find a battle-hardened library for your specific platform to do this heavy lifting. 
+You can find an extensive list of libraries on <a href='https://jwt.io/libraries' target="_blank">jwt.io</a>. Alternatively, Criipto provides a list of [integrations](/verify/integrations) that handle most of the authentication process, including JWT validation.
+
+For more informaiton, see [OpenID Connect security best practices](/verify/getting-started/best-security-practices/#always-validating-id-tokens) and <a href='https://www.criipto.com/blog/jwt-validation-guide' target="_blank">JWT validation guide</a>.
 
 ## The 'scope' parameter
 

--- a/src/pages/verify/getting-started/oidc-intro.mdx
+++ b/src/pages/verify/getting-started/oidc-intro.mdx
@@ -25,7 +25,7 @@ The Authorization Code Flow is used for traditional server-based web application
 The PKCE Flow (pronounced _pixy_) can be used by _public clients_ such as single-page applications (SPAs) and native applications that cannot keep a secret. With PKCE, a one-time secret is generated and used for the code exchange.
 
 #### [3. The Implicit Flow](/verify/getting-started/oidc-intro/#authenticate-with-implicit-flow)
-The Implicit Flow (now deprecated) returns a token directly in the browser. Support for this flow is being discontinued, although it will continue to function on test domains for the foreseeable future for simpler debugging during development.
+The Implicit Flow returns a token directly in the browser. Support for this flow is being discontinued, although it will continue to function on test domains for the foreseeable future for simpler debugging during development.
 
 #### [4. The CIBA flow](/verify/getting-started/oidc-intro/#authenticate-with-ciba)
 The CIBA flow is designed for use cases where the client application isn't directly operated by the end-user but can trigger the authentication process on their behalf. A canonical example is a call center agent verifying a caller's identity.

--- a/src/pages/verify/getting-started/rate-limiting.mdx
+++ b/src/pages/verify/getting-started/rate-limiting.mdx
@@ -1,7 +1,7 @@
 ---
 product: verify
 category: Getting Started
-sort: 4
+sort: 5
 title: Rate limiting
 subtitle: Learn more about SSO rate limiting.
 ---

--- a/src/pages/verify/getting-started/token-contents.mdx
+++ b/src/pages/verify/getting-started/token-contents.mdx
@@ -1,7 +1,7 @@
 ---
 product: verify
 category: Getting Started
-sort: 3
+sort: 4
 title: JWT payloads pr. eID type
 subtitle: Examples of JWT payloads for selected eIDs
 ---

--- a/src/pages/verify/integrations/javascript.mdx
+++ b/src/pages/verify/integrations/javascript.mdx
@@ -92,7 +92,7 @@ The `CriiptoAuth` constructor takes an object with the following parameters:
 
 Use your application's [domain and client ID](#register-your-application-in-criipto-verify) as the values for `domain` and `clientID` respectively.
 
-Additional authorization parameters can be passed in the `CriiptoAuth` constructor as well. A full list of supported parameters can be found [here](/verify/getting-started/oidc-intro/#example-authentication-url).
+Additional authorization parameters can be passed in the `CriiptoAuth` constructor as well. For all available options, see [the full list of supported parameters](/verify/getting-started/oidc-intro#authorize-request-parameters).
 
 ## Authorization methods
 
@@ -197,7 +197,7 @@ console.log(match.id_token, match.claims);
 </script>
 ```
 
-`prompt: 'login'` will force the user to re-authenticate even if they have already logged in. See [the list of supported parameters](/verify/getting-started/oidc-intro/#example-authentication-url) for more information.
+`prompt: 'login'` will force the user to re-authenticate even if they have already logged in. See [the list of supported parameters](/verify/getting-started/oidc-intro#authorize-request-parameters) for more information.
 
 ## Logging user out
 

--- a/src/pages/verify/integrations/vuejs.mdx
+++ b/src/pages/verify/integrations/vuejs.mdx
@@ -68,7 +68,7 @@ The `CriiptoAuth` constructor takes an object with the following parameters:
 
 Use your application's [domain and client ID](#register-your-application-in-criipto-verify) as the values for `domain` and `clientID` respectively.
 
-Additional authorization parameters can be passed in the `CriiptoAuth` constructor as well. A full list of supported parameters can be found [here](/verify/getting-started/oidc-intro/#example-authentication-url).
+Additional authorization parameters can be passed in the `CriiptoAuth` constructor as well. For all available options, see [the full list of supported parameters](/verify/getting-started/oidc-intro#authorize-request-parameters).
 
 ## Authorization methods
 
@@ -203,7 +203,7 @@ onMounted(() => {
 </template>
 ```
 
-`prompt: 'login'` will force the user to re-authenticate even if they have already logged in. See [the list of supported parameters](/verify/getting-started/oidc-intro/#example-authentication-url) for more information.
+`prompt: 'login'` will force the user to re-authenticate even if they have already logged in. See [the list of supported parameters](/verify/getting-started/oidc-intro#authorize-request-parameters) for more information.
 
 ## Logging user out
 


### PR DESCRIPTION
1. Added OIDC best security practices guide.
2. Updated the **Using OpenID Connect** section
 - Moved flow types description to a separate section;
 - Improved cross-referencing;
 - Capitalized the names of the flows (_implicit flow_ => _Implicit Flow_) following OIDC specification;
 - Change wording from Example _authentication_ URL to Example _authorization_ URL, and updated linking;
3. Updated links to reflect the changes. 
4. Some minor typos are fixed.

UPD: included a note about using PKCE and `nonce` alongside one another (and not as an alternative) based on [PKCE vs. Nonce: Equivalent or Not?](https://danielfett.de/2020/05/16/pkce-vs-nonce-equivalent-or-not/)