### PR TITLE
Fix table layouts.

### DIFF
--- a/src/pages/verify/e-ids/danish-mitid.mdx
+++ b/src/pages/verify/e-ids/danish-mitid.mdx
@@ -331,14 +331,36 @@ The key elements of the default styling are shown below, but we suggest to simpl
 ```
 
 The text inside the button must be from the set of approved texts:
-
-| &nbsp;&nbsp;**Danish** | &nbsp;&nbsp;**English** |
-| --- | --- |
-| Log ind med MitID | Log on with MitID |
-| Godkend med MitID | Approve with MitID |
-| Bekræft med MitID | Confirm with MitID |
-| Acceptér med MitID | Accept with MitID |
-| Underskriv med MitID | Sign with MitID |
+<table>
+    <thead>
+        <tr>
+            <th>**Danish**</th>
+            <th>**English**</th>
+        </tr>
+    </thead>
+    <tbody>
+        <tr>
+            <td>Log ind med MitID</td>
+            <td>Log on with MitID</td>
+        </tr>
+        <tr>
+            <td>Godkend med MitID</td>
+            <td>Approve with MitID</td>
+        </tr>
+        <tr>
+            <td>Bekræft med MitID</td>
+            <td>Confirm with MitID</td>
+        </tr>
+        <tr>
+            <td>Acceptér med MitID</td>
+            <td>Accept with MitID</td>
+        </tr>
+        <tr>
+            <td>Underskriv med MitID</td>
+            <td>Sign with MitID</td>
+        </tr>
+    </tbody>
+</table>
 
 ### MitID branding in a native app
 

--- a/src/pages/verify/e-ids/norwegian-bankid.mdx
+++ b/src/pages/verify/e-ids/norwegian-bankid.mdx
@@ -111,14 +111,61 @@ Basic user information, full name, and date of birth are always made available. 
 
 For applications configured to use a `dynamic` `scope` strategy, the following `scope` tokens can be supplied: `address`, `email`, `phone` and `ssn`.
 
-| **Data type**                      | **Released**      | **Verified** | **scope** | **login_hint**  |
-| ---------------------------------- | ----------------- | ------------ | --------- | --------------- |
-| Full name                          | Always            | Yes          |           |                 |
-| Date of birth                      | Always            | Yes          |           |                 |
-| SSN ("fødselsnummer" in Norwegian) | User consent      | Yes          | `ssn`     | `scope:ssn`     |
-| Address                            | With user consent | No           | `address` | `scope:address` |
-| Email                              | With user consent | No           | `email`   | `scope:email`   |
-| Phone number                       | With user consent | No           | `phone`   | `scope:phone`   |
+<table>
+    <thead>
+        <tr>
+            <th>**Data type**</th>
+            <th>**Released**</th>
+            <th>**Verified**</th>
+            <th>**scope**</th>
+            <th>**login_hint**</th>
+        </tr>
+    </thead>
+    <tbody>
+        <tr>
+            <td>Full name</td>
+            <td>Always</td>
+            <td>Yes</td>
+            <td></td>
+            <td></td>
+        </tr>
+        <tr>
+            <td>Date of birth</td>
+            <td>Always</td>
+            <td>Yes</td>
+            <td></td>
+            <td></td>
+        </tr>
+        <tr>
+            <td>SSN ("fødselsnummer" in Norwegian)</td>
+            <td>User consent</td>
+            <td>Yes</td>
+            <td>`ssn`</td>
+            <td>`scope:ssn`</td>
+        </tr>
+        <tr>
+            <td>Address</td>
+            <td>With user consent</td>
+            <td>No</td>
+            <td>`address`</td>
+            <td>`scope:address`</td>
+        </tr>
+        <tr>
+            <td>Email</td>
+            <td>With user consent</td>
+            <td>No</td>
+            <td>`email`</td>
+            <td>`scope:email`</td>
+        </tr>
+        <tr>
+            <td>Phone number</td>
+            <td>With user consent</td>
+            <td>No</td>
+            <td>`phone`</td>
+            <td>`scope:phone`</td>
+        </tr>
+    </tbody>
+</table>
 
 #### Example (partial) authorize request with scopes
 ```text

--- a/src/snippets/login-methods-and-path-encoded.mdx
+++ b/src/snippets/login-methods-and-path-encoded.mdx
@@ -1,25 +1,126 @@
-| **Login method** | **acr_values** | **base64 encoded** |
-| --- | --- | --- |
-| **Norwegian BankID** |
-| &nbsp;&nbsp;Mobile or Web (user choice):&nbsp;          | `urn:grn:authn:no:bankid` | `dXJuOmdybjphdXRobjpubzpiYW5raWQ=` |
-| &nbsp;&nbsp;BankID Biometrics (level substantial):&nbsp;| `urn:grn:authn:no:bankid:substantial` | `dXJuOmdybjphdXRobjpubzpiYW5raWQ6c3Vic3RhbnRpYWw=` |
-| **Norwegian Vipps Login** |
-| &nbsp;&nbsp;Login with Vipps app:&nbsp;                 | `urn:grn:authn:no:vipps` | `dXJuOmdybjphdXRobjpubzp2aXBwcw==` |
-| **Swedish BankID** |
-| &nbsp;&nbsp;All options (user chooses):&nbsp;           | `urn:grn:authn:se:bankid` | `dXJuOmdybjphdXRobjpzZTpiYW5raWQ=` |
-| &nbsp;&nbsp;Same device:                                | `urn:grn:authn:se:bankid:same-device` | `dXJuOmdybjphdXRobjpzZTpiYW5raWQ6c2FtZS1kZXZpY2U=` |
-| &nbsp;&nbsp;Another device (aka mobile):&nbsp;          | `urn:grn:authn:se:bankid:another-device` | `dXJuOmdybjphdXRobjpzZTpiYW5raWQ6YW5vdGhlci1kZXZpY2U=` |
-| &nbsp;&nbsp;QR code:&nbsp;                              | `urn:grn:authn:se:bankid:another-device:qr` | `dXJuOmdybjphdXRobjpzZTpiYW5raWQ6YW5vdGhlci1kZXZpY2U6cXI=` |
-| **Danish MitID** |
-| &nbsp;&nbsp;Level low:&nbsp;                            | `urn:grn:authn:dk:mitid:low` | `dXJuOmdybjphdXRobjpkazptaXRpZDpsb3c=` |
-| &nbsp;&nbsp;Level substantial:&nbsp;                    | `urn:grn:authn:dk:mitid:substantial` | `dXJuOmdybjphdXRobjpkazptaXRpZDpzdWJzdGFudGlhbA==` |
-| &nbsp;&nbsp;MitID Erhverv (MitID Business):&nbsp;       | `urn:grn:authn:dk:mitid:business` | `dXJuOmdybjphdXRobjpkazptaXRpZDpidXNpbmVzcw==` |
-| **Finnish Trust Network** |
-| &nbsp;&nbsp;BankID:                                     |`urn:grn:authn:fi:bankid` | `dXJuOmdybjphdXRobjpmaTpiYW5raWQ=` |
-| &nbsp;&nbsp;Mobile certificate (Mobiilivarmenne):&nbsp; |`urn:grn:authn:fi:mobile-id` | `dXJuOmdybjphdXRobjpmaTptb2JpbGUtaWQ=` |
-| &nbsp;&nbsp;Both of the above:                          |`urn:grn:authn:fi:all` | `dXJuOmdybjphdXRobjpmaTphbGw=` |
-| **Itsme** |
-| &nbsp;&nbsp;Basic:&nbsp;                                | `urn:grn:authn:itsme:basic` | `dXJuOmdybjphdXRobjppdHNtZTpiYXNpYw==` |
-| &nbsp;&nbsp;Advanced:&nbsp;                             | `urn:grn:authn:itsme:advanced` | `dXJuOmdybjphdXRobjppdHNtZTphZHZhbmNlZA==` |
-| **Belgium** |
-| &nbsp;&nbsp;Verified e-ID:&nbsp;                        | `urn:grn:authn:be:eid:verified` | `dXJuOmdybjphdXRobjpiZTplaWQ6dmVyaWZpZWQ=` |
+<table>
+    <thead>
+        <tr>
+            <th>**Login method**</th>
+            <th>**acr_values**</th>
+            <th>**base64 encoded**</th>
+        </tr>
+    </thead>
+    <tbody>
+        <tr>
+            <td>**Norwegian BankID**</td>
+            <td></td>
+            <td></td>
+        </tr>
+        <tr>
+            <td>Mobile or Web (user choice):</td>
+            <td>`urn:grn:authn:no:bankid`</td>
+            <td>`dXJuOmdybjphdXRobjpubzpiYW5raWQ=`</td>
+        </tr>
+        <tr>
+            <td>BankID Biometrics (level substantial):</td>
+            <td>`urn:grn:authn:no:bankid:substantial`</td>
+            <td>`dXJuOmdybjphdXRobjpubzpiYW5raWQ6c3Vic3RhbnRpYWw=`</td>
+        </tr>
+        <tr>
+            <td>**Norwegian Vipps Login**</td>
+            <td></td>
+            <td></td>
+        </tr>
+        <tr>
+            <td>Login with Vipps app:</td>
+            <td>`urn:grn:authn:no:vipps`</td>
+            <td>`dXJuOmdybjphdXRobjpubzp2aXBwcw==`</td>
+        </tr>
+        <tr>
+            <td>**Swedish BankID**</td>
+            <td></td>
+            <td></td>
+        </tr>
+        <tr>
+            <td>All options (user chooses):</td>
+            <td>`urn:grn:authn:se:bankid`</td>
+            <td>`dXJuOmdybjphdXRobjpzZTpiYW5raWQ=`</td>
+        </tr>
+        <tr>
+            <td>Same device:</td>
+            <td>`urn:grn:authn:se:bankid:same-device`</td>
+            <td>`dXJuOmdybjphdXRobjpzZTpiYW5raWQ6c2FtZS1kZXZpY2U=`</td>
+        </tr>
+        <tr>
+            <td>Another device (aka mobile):</td>
+            <td>`urn:grn:authn:se:bankid:another-device`</td>
+            <td>`dXJuOmdybjphdXRobjpzZTpiYW5raWQ6YW5vdGhlci1kZXZpY2U=`</td>
+        </tr>
+        <tr>
+            <td>QR code:</td>
+            <td>`urn:grn:authn:se:bankid:another-device:qr`</td>
+            <td>`dXJuOmdybjphdXRobjpzZTpiYW5raWQ6YW5vdGhlci1kZXZpY2U6cXI=`</td>
+        </tr>
+        <tr>
+            <td>**Danish MitID**</td>
+            <td></td>
+            <td></td>
+        </tr>
+        <tr>
+            <td>Level low:</td>
+            <td>`urn:grn:authn:dk:mitid:low`</td>
+            <td>`dXJuOmdybjphdXRobjpkazptaXRpZDpsb3c=`</td>
+        </tr>
+        <tr>
+            <td>Level substantial:</td>
+            <td>`urn:grn:authn:dk:mitid:substantial`</td>
+            <td>`dXJuOmdybjphdXRobjpkazptaXRpZDpzdWJzdGFudGlhbA==`</td>
+        </tr>
+        <tr>
+            <td>MitID Erhverv (MitID Business):</td>
+            <td>`urn:grn:authn:dk:mitid:business`</td>
+            <td>`dXJuOmdybjphdXRobjpkazptaXRpZDpidXNpbmVzcw==`</td>
+        </tr>
+        <tr>
+            <td>**Finnish Trust Network**</td>
+            <td></td>
+            <td></td>
+        </tr>
+        <tr>
+            <td>BankID:</td>
+            <td>`urn:grn:authn:fi:bankid`</td>
+            <td>`dXJuOmdybjphdXRobjpmaTpiYW5raWQ=`</td>
+        </tr>
+        <tr>
+            <td>Mobile certificate (Mobiilivarmenne):</td>
+            <td>`urn:grn:authn:fi:mobile-id`</td>
+            <td>`dXJuOmdybjphdXRobjpmaTptb2JpbGUtaWQ=`</td>
+        </tr>
+        <tr>
+            <td>Both of the above:</td>
+            <td>`urn:grn:authn:fi:all`</td>
+            <td>`dXJuOmdybjphdXRobjpmaTphbGw=`</td>
+        </tr>
+        <tr>
+            <td>**Itsme**</td>
+            <td></td>
+            <td></td>
+        </tr>
+        <tr>
+            <td>Basic:</td>
+            <td>`urn:grn:authn:itsme:basic`</td>
+            <td>`dXJuOmdybjphdXRobjppdHNtZTpiYXNpYw==`</td>
+        </tr>
+        <tr>
+            <td>Advanced:</td>
+            <td>`urn:grn:authn:itsme:advanced`</td>
+            <td>`dXJuOmdybjphdXRobjppdHNtZTphZHZhbmNlZA==`</td>
+        </tr>
+        <tr>
+            <td>**Belgium**</td>
+            <td></td>
+            <td></td>
+        </tr>
+        <tr>
+            <td>Verified e-ID:</td>
+            <td>`urn:grn:authn:be:eid:verified`</td>
+            <td>`dXJuOmdybjphdXRobjpiZTplaWQ6dmVyaWZpZWQ=`</td>
+        </tr>
+    </tbody>
+</table>

--- a/src/snippets/login-methods.mdx
+++ b/src/snippets/login-methods.mdx
@@ -5,27 +5,101 @@ To pick the login method you must set the `acr_values` parameter on the authenti
 
 The current list of possible values is:
 
-| **Login method** | **acr_values** |
-| --- | --- |
-| **Norwegian BankID** |
-| &nbsp;&nbsp;Mobile or Web (user choice):&nbsp;         | `urn:grn:authn:no:bankid` |
-| **Norwegian Vipps Login** |
-| &nbsp;&nbsp;Login with Vipps app:&nbsp;                | `urn:grn:authn:no:vipps` |
-| **Swedish BankID** |
-| &nbsp;&nbsp;All options (user chooses):&nbsp;          | `urn:grn:authn:se:bankid` |
-| &nbsp;&nbsp;Same device:                               | `urn:grn:authn:se:bankid:same-device` |
-| &nbsp;&nbsp;Another device (aka mobile):&nbsp;         | `urn:grn:authn:se:bankid:another-device` |
-| &nbsp;&nbsp;QR code:&nbsp;                             | `urn:grn:authn:se:bankid:another-device:qr` |
-| **Danish MitID** |
-| &nbsp;&nbsp;Level low:&nbsp;                           | `urn:grn:authn:dk:mitid:low` |
-| &nbsp;&nbsp;Level substantial:&nbsp;                   | `urn:grn:authn:dk:mitid:substantial` |
-| &nbsp;&nbsp;MitID Erhverv (MitID Business):&nbsp;      | `urn:grn:authn:dk:mitid:business` |
-| **Finnish Trust Network** |
-| &nbsp;&nbsp;BankID:                                    |`urn:grn:authn:fi:bank-id` |
-| &nbsp;&nbsp;Mobile certificate (Mobiilivarmenne):&nbsp;|`urn:grn:authn:fi:mobile-id` |
-| &nbsp;&nbsp;Both of the above:                         |`urn:grn:authn:fi:all` |
-| **Itsme** |
-| &nbsp;&nbsp;Basic:                                     | `urn:grn:authn:itsme:basic` |
-| &nbsp;&nbsp;Advanced:                                  | `urn:grn:authn:itsme:advanced` |
-| **Belgium** |
-| &nbsp;&nbsp;Verified e-ID                              | `urn:grn:authn:be:eid:verified` |
+<table>
+    <thead>
+        <tr>
+            <th>**Login method**</th>
+            <th>**acr_values**</th>
+        </tr>
+    </thead>
+    <tbody>
+        <tr>
+            <td>**Norwegian BankID**</td>
+            <td></td>
+        </tr>
+        <tr>
+            <td>Mobile or Web (user choice):</td>
+            <td>`urn:grn:authn:no:bankid`</td>
+        </tr>
+        <tr>
+            <td>**Norwegian Vipps Login**</td>
+            <td></td>
+        </tr>
+        <tr>
+            <td>Login with Vipps app:</td>
+            <td>`urn:grn:authn:no:vipps`</td>
+        </tr>
+        <tr>
+            <td>**Swedish BankID**</td>
+            <td></td>
+        </tr>
+        <tr>
+            <td>All options (user chooses):</td>
+            <td>`urn:grn:authn:se:bankid`</td>
+        </tr>
+        <tr>
+            <td>Same device:</td>
+            <td>`urn:grn:authn:se:bankid:same-device`</td>
+        </tr>
+        <tr>
+            <td>Another device (aka mobile):</td>
+            <td>`urn:grn:authn:se:bankid:another-device`</td>
+        </tr>
+        <tr>
+            <td>QR code:</td>
+            <td>`urn:grn:authn:se:bankid:another-device:qr`</td>
+        </tr>
+        <tr>
+            <td>**Danish MitID**</td>
+            <td></td>
+        </tr>
+        <tr>
+            <td>Level low:</td>
+            <td>`urn:grn:authn:dk:mitid:low`</td>
+        </tr>
+        <tr>
+            <td>Level substantial:</td>
+            <td>`urn:grn:authn:dk:mitid:substantial`</td>
+        </tr>
+        <tr>
+            <td>MitID Erhverv (MitID Business):</td>
+            <td>`urn:grn:authn:dk:mitid:business`</td>
+        </tr>
+        <tr>
+            <td>**Finnish Trust Network**</td>
+            <td></td>
+        </tr>
+        <tr>
+            <td>BankID:</td>
+            <td>`urn:grn:authn:fi:bank-id`</td>
+        </tr>
+        <tr>
+            <td>Mobile certificate (Mobiilivarmenne):</td>
+            <td>`urn:grn:authn:fi:mobile-id`</td>
+        </tr>
+        <tr>
+            <td>Both of the above:</td>
+            <td>`urn:grn:authn:fi:all`</td>
+        </tr>
+        <tr>
+            <td>**Itsme**</td>
+            <td></td>
+        </tr>
+        <tr>
+            <td>Basic:</td>
+            <td>`urn:grn:authn:itsme:basic`</td>
+        </tr>
+        <tr>
+            <td>Advanced:</td>
+            <td>`urn:grn:authn:itsme:advanced`</td>
+        </tr>
+        <tr>
+            <td>**Belgium**</td>
+            <td></td>
+        </tr>
+        <tr>
+            <td>Verified e-ID</td>
+            <td>`urn:grn:authn:be:eid:verified`</td>
+        </tr>
+    </tbody>
+</table>


### PR DESCRIPTION
Markdown tables were broken by a recent dependency upgrade. This fixes them by converting them to HTML tables.