### PR TITLE
Close sidenav on navigation link click (on mobile) + fix layout for long titles in the top nav on mobile

### DIFF
--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -1,4 +1,4 @@
-import React, {useEffect, useReducer, useState} from 'react';
+import React, {useEffect, useReducer, useState, useRef } from 'react';
 import { Link } from "gatsby";
 
 import Search from './Search';
@@ -6,6 +6,7 @@ import logo from '../images/criipto-logo.png';
 
 export default function Header(props: {path: string | undefined, className?: string}) {
   const [showDropdown, toggleDropdown] = useReducer((value) => !value, false);
+  const dropdownRef = useRef<HTMLDivElement | null>(null);
   const [showSearch, setShowSearch] = useState(false);
   const {path} = props;
   const isVerify = path?.startsWith('/verify');
@@ -20,6 +21,21 @@ export default function Header(props: {path: string | undefined, className?: str
     document.addEventListener('keyup', handler);
     return () => document.removeEventListener('keyup', handler);
   }, []);
+
+  // Close dropdown when clicking outside
+  useEffect(() => {
+    function handleClickOutside(event: MouseEvent): void {
+      if (dropdownRef.current && !dropdownRef.current.contains(event.target as Node)) {
+        toggleDropdown();
+      }
+    }
+
+    document.addEventListener("mousedown", handleClickOutside);
+    return () => {
+      document.removeEventListener("mousedown", handleClickOutside);
+    };
+  }, []);
+
 
   return (
     <React.Fragment>
@@ -58,8 +74,8 @@ export default function Header(props: {path: string | undefined, className?: str
                   )}
                 </button>
                 {showDropdown && (
-                  <div className="absolute top-full mt-1 py-2 w-60 rounded-lg bg-white shadow ring-1 ring-gray-900/5 leading-6 font-medium uppercase text-deep-purple-900 z-60">
-                    <Link to="/verify">
+                  <div className="absolute top-full mt-1 py-2 w-60 rounded-lg bg-white shadow ring-1 ring-gray-900/5 leading-6 font-medium uppercase text-deep-purple-900 z-60" ref={dropdownRef}>
+                    <Link to="/verify" onClick={toggleDropdown}>
                       <span className="flex items-center justify-between px-3 py-1 text-deep-purple-900 hover:text-primary-600">
                         Verify (eIDs)
                         {isVerify && (
@@ -67,7 +83,7 @@ export default function Header(props: {path: string | undefined, className?: str
                         )}
                       </span>
                     </Link>
-                    <Link to="/signatures">
+                    <Link to="/signatures" onClick={toggleDropdown}>
                       <span className="flex items-center justify-between px-3 py-1 text-deep-purple-900 hover:text-primary-600">
                         Signatures
                         {isSignatures && (

--- a/src/components/Navigation.tsx
+++ b/src/components/Navigation.tsx
@@ -32,6 +32,7 @@ function slugToPath(slug: string) {
 interface Props {
   path: string | undefined
   hidden?: boolean
+  onLinkClick?: () => void;
 }
 
 const navigationQuery = gatsbyGraphql`query Navigation {
@@ -98,7 +99,7 @@ export default function Navigation(props: Props) {
     return (
       <ul>
         <li>
-          <Link to="/verify" className="block mb-3 font-medium text-primary-600 text-lg">
+          <Link to="/verify" className="block mb-3 font-medium text-primary-600 text-lg" onClick={props.onLinkClick}>
             Criipto Verify
           </Link>
           <ul className="space-y-2 border-l border-gray-100 text-md font-normal">
@@ -107,6 +108,7 @@ export default function Navigation(props: Props) {
                 <Link
                   to={slugToPath(findIndexPage(category, verifyPages)!.fields!.slug!)}
                   className="block border-l pl-4 py-1 lg:py-0 -ml-px border-transparent hover:border-gray-400 text-primary-600 hover:text-deep-purple-900 hover:font-medium"
+                  onClick={props.onLinkClick}          
                 >
                   {category}
                 </Link>
@@ -115,13 +117,14 @@ export default function Navigation(props: Props) {
             <Link
               to="/verify/articles"
               className="block border-l pl-4 py-1 lg:py-0 -ml-px border-transparent hover:border-gray-400 text-primary-600 hover:text-deep-purple-900 hover:font-medium"
+              onClick={props.onLinkClick}
             >
               Articles
             </Link>
           </ul>
         </li>
         <li className="mt-8">
-          <Link to="/signatures" className="block mb-3 font-medium text-primary-600 text-lg">
+          <Link to="/signatures" className="block mb-3 font-medium text-primary-600 text-lg" onClick={props.onLinkClick}>
             Criipto Signatures
           </Link>
           <ul className="space-y-2 border-l border-gray-100 text-md font-normal">
@@ -130,6 +133,7 @@ export default function Navigation(props: Props) {
                 <Link
                   to={slugToPath(findIndexPage(category, signaturesPages)!.fields!.slug!)}
                   className="block border-l pl-4 py-1 lg:py-0 -ml-px border-transparent hover:border-gray-400 text-primary-600 hover:text-deep-purple-900 hover:font-medium"
+                  onClick={props.onLinkClick}
                 >
                   {category}
                 </Link>
@@ -149,13 +153,14 @@ export default function Navigation(props: Props) {
       {categories.map((category, index) => (
         <li key={category} className={index > 0 ? 'mt-8' : ''}>
           {findIndexPage(category, pages) ? (
-            <Link to={slugToPath(findIndexPage(category, pages)!.fields!.slug!)} className="block mb-3 font-medium text-primary-600">{category}</Link>
+            <Link to={slugToPath(findIndexPage(category, pages)!.fields!.slug!)} className="block mb-3 font-medium text-primary-600"  onClick={props.onLinkClick}>{category}</Link>
           ) : (
             <h5 className="mb-3 font-medium text-primary-600">{category}</h5>
           )}
           <ul className="space-y-2 border-l border-gray-100 text-md font-normal">
             {isVerify && category === 'Guides & Tools' && (
               <Link
+                onClick={props.onLinkClick}
                 to="/verify/articles"
                 getProps={(props) => ({className: `block border-l pl-4 py-1 lg:py-0 -ml-px border-transparent ${props.isCurrent ? 'text-deep-purple-900 border-current font-medium' : 'hover:border-gray-400 text-primary-600 hover:text-deep-purple-900 hover:font-medium'}`})}
               >
@@ -165,6 +170,7 @@ export default function Navigation(props: Props) {
             {pages.filter(node => !isIndexPage(node) && node.frontmatter?.category === category).map(page => (
               <li key={page.id}>
                 <Link
+                  onClick={props.onLinkClick}
                   to={slugToPath(page.fields!.slug!)}
                   getProps={(props) => ({className: `block border-l pl-4 py-1 lg:py-0 -ml-px border-transparent ${props.isCurrent ? 'text-deep-purple-900 border-current font-medium' : 'hover:border-gray-400 text-primary-600 hover:text-deep-purple-900 hover:font-medium'}`})}
                 >
@@ -234,7 +240,7 @@ export function MobileNavigation(props: Props & MobileProps) {
                   <path d="M0 0L3 3L0 6" fill="none" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round"></path>
                 </svg>
               </li>
-              <li className="font-medium text-slate-900 truncate ">
+              <li className="font-medium text-slate-900 max-w-8 whitespace-normal">
                 {title}
               </li>
             </ol>
@@ -258,8 +264,7 @@ export function MobileNavigation(props: Props & MobileProps) {
               <path d="M0 0L10 10M10 0L0 10" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round"></path>
             </svg>
           </button>
-
-          <Navigation {...props} />
+          <Navigation {...props} onLinkClick={() => setShowNavigation(false)} /> 
         </div>
       </div>
 


### PR DESCRIPTION
1. Currently, when a navigation link is clicked on mobile, side navigation remains open. I added `onLinkClick` callback and used it in `MobileNavigation` so that navigating to a page closes side navigation.
2. On mobile, long titles in the top nav are breaking the layout. Updated styles fix this (see screenshots).
3. Fixed Verify/Signatures dropdown to close when a product is selected

<img width="375" alt="screenshot_1" src="https://github.com/user-attachments/assets/a172391c-e180-45af-8dfa-185985277e1b" />
<img width="376" alt="screenshot_2" src="https://github.com/user-attachments/assets/291d9c34-e126-4b4f-985c-c661bbb0bf1b" />
