### PR TITLE
Add test users page

### DIFF
--- a/src/pages/verify/guides/test-users.mdx
+++ b/src/pages/verify/guides/test-users.mdx
@@ -1,0 +1,54 @@
+---
+product: verify
+category: Guides & Tools
+sort: 0
+title: Creating test users
+subtitle: How to create test users and set up test apps for different eIDs
+---
+
+import {isIndexPage} from '../../../utils';
+
+import { graphql as gatsbyGraphql, Link } from "gatsby";
+
+export const pageQuery = gatsbyGraphql`
+  query eIDs {
+    pages: allMdx(
+      filter: {
+        frontmatter: {
+          product: { eq: "verify" }
+          category: { eq: "eIDs" }
+        }
+      }
+      sort: {frontmatter: {sort: ASC}}
+    ) {
+      edges {
+        node {
+          __typename
+          id
+          frontmatter {
+            title
+          }
+          fields {
+            slug
+          }
+          internal {
+            contentFilePath
+          }
+        }
+      }
+    }
+  }
+`;
+
+To run test logins with most eIDs, you'll need to create a test user and install a test app. Find instructions for each eID in the links below.
+
+<ul>
+  {props.data.pages.edges.map(edge => edge.node).filter(node => !isIndexPage(node)).filter(node => node.frontmatter.title !== "Dutch iDIN" && node.frontmatter.title !== "German Personalausweis").map(node => (
+    <li key={node.id}>
+      <Link to={`/${node.fields.slug}/#test-users`}>{node.frontmatter.title}</Link><br />
+    </li>
+  ))}
+    <li>
+      <Link to="/verify/e-ids/german-personalausweis/#testing">German Personalausweis</Link><br />
+    </li>
+</ul>


### PR DESCRIPTION
While working on the new Dashboard homepage design and content, we realized we're missing a dedicated page for creating test users. Currently, we have to link to the [eIDs page](https://docs.criipto.com/verify/e-ids/) and ask users to find their way from there, which isn't ideal. 
I'm adding a page with direct links to the testing instructions. 