### PR TITLE
Fix Integrations page displaying index.mdx in a list of integrations

### DIFF
--- a/src/pages/verify/integrations/index.mdx
+++ b/src/pages/verify/integrations/index.mdx
@@ -31,6 +31,9 @@ export const pageQuery = gatsbyGraphql`
           fields {
             slug
           }
+          internal {
+            contentFilePath
+          }
         }
       }
     }


### PR DESCRIPTION
Solved by adding `contentFilePath` to `pageQuery`