### PR TITLE
Fix svg styles (currently loading wrong icon size)

### DIFF
--- a/src/components/MdxProvider.tsx
+++ b/src/components/MdxProvider.tsx
@@ -152,7 +152,7 @@ export const Highlight = (props: {children: React.ReactNode, icon?: string, warn
   return (
     <div className={`mdx-highlight bg-gray-200 ${props.warning ? 'bg-yellow-100' : ''} rounded-md p-4 max-w-screen-md ${props.icon ? 'relative pl-10' : ''}`}>
       {props.icon ? (
-        <FontAwesomeIcon className="absolute left-4 top-4 text-2xl" icon={`fa-solid fa-${props.icon}` as any} />
+        <FontAwesomeIcon style={{ height: "1.5rem" }} className="absolute left-4 top-4 text-2xl" icon={`fa-solid fa-${props.icon}` as any} />
       ) : null}
       
       {props.children}


### PR DESCRIPTION
We noticed that SVG icons in `Highlight` initially loaded at incorrect size: a huge icon appearing for the first second before resizing correctly can be spotted at [German Personalausweis](https://docs.criipto.com/verify/e-ids/german-personalausweis/) and [Norwegian BankID](https://docs.criipto.com/verify/e-ids/norwegian-bankid/)) pages. 
Fixed by adding inline `height` to the icon.

_Strangely, I couldn't reproduce the bug on localhost — only in production and deploy previews._