### PR TITLE
Inline Signatures GraphQL Explorer as part of docs

### DIFF
--- a/gatsby-browser.tsx
+++ b/gatsby-browser.tsx
@@ -17,6 +17,7 @@ import { fas } from '@fortawesome/free-solid-svg-icons'
 
 import MdxLayout from './src/layouts/mdx';
 import DefaultLayout from './src/layouts/default';
+import FullscreenLayout from './src/layouts/fullscreen';
 
 import wrapWithProvider from "./src/state/wrap-with-provider";
 export const wrapRootElement : GatsbyBrowser["wrapRootElement"] = wrapWithProvider;
@@ -30,6 +31,15 @@ export const wrapPageElement : GatsbyBrowser["wrapPageElement"] = ({props, eleme
       >
         {element}
       </DefaultLayout>
+    );
+  }
+  if ((props.pageContext as any).frontmatter?.layout === 'fullscreen') {
+    return (
+      <FullscreenLayout
+        {...props}
+      >
+        {element}
+      </FullscreenLayout>
     );
   }
   if (!(props.pageContext as any).frontmatter) {

--- a/gatsby-ssr.tsx
+++ b/gatsby-ssr.tsx
@@ -5,6 +5,7 @@ import { fas } from '@fortawesome/free-solid-svg-icons'
 import wrapWithProvider from "./src/state/wrap-with-provider";
 import MdxLayout from './src/layouts/mdx';
 import DefaultLayout from './src/layouts/default';
+import FullscreenLayout from './src/layouts/fullscreen';
 
 export const wrapRootElement : GatsbySSR["wrapRootElement"] = wrapWithProvider;
 library.add(fas);
@@ -17,6 +18,16 @@ export const wrapPageElement : GatsbySSR["wrapPageElement"] = ({props, element})
       >
         {element}
       </DefaultLayout>
+    );
+  }
+  console.log((props.pageContext as any).frontmatter?.layout);
+  if ((props.pageContext as any).frontmatter?.layout === 'fullscreen') {
+    return (
+      <FullscreenLayout
+        {...props}
+      >
+        {element}
+      </FullscreenLayout>
     );
   }
   if (!(props.pageContext as any).frontmatter) {

--- a/src/components/GraphQLExplorer.tsx
+++ b/src/components/GraphQLExplorer.tsx
@@ -1,4 +1,5 @@
 import React, {useState, useMemo, useCallback} from 'react';
+import cx from 'classnames';
 import GraphiQL from 'graphiql';
 import { Link } from 'gatsby';
 
@@ -72,6 +73,7 @@ interface GraphQLExplorerProps {
   onResponse?: (response: GraphQLResponse) => void,
   onSkipCredentials?: () => void,
   style?: React.CSSProperties
+  fullscreen?: boolean
 }
 export default function GraphQLExplorer(props: GraphQLExplorerProps) {
   const {query, variables} = props;
@@ -94,13 +96,20 @@ export default function GraphQLExplorer(props: GraphQLExplorerProps) {
   const graphqlFetcher = useMemo(() => graphQLFetcherFactory(credentials, handleResponse), [credentials, handleResponse]);
 
   return (
-    <div className={props.className}>
+    <div 
+      className={cx({
+        'h-svh flex flex-col': props.fullscreen
+      }, props.className)}
+      style={props.fullscreen ? {height: '100svh'} : {}}
+    >
       {credentials && (
         <p className="bg-gray-300 p-2 rounded-t mb-0" style={props.style}>
           Queries are executed against your actual application. Please make sure you are using test credentials.
         </p>
       )}
-      <div style={{height: "700px"}} className="relative">
+      <div style={props.fullscreen ? {} : {height: "700px"}} className={cx("relative", {
+        'flex-1': props.fullscreen
+      })}>
         <GraphiQL
           fetcher={graphqlFetcher as any}
           defaultVariableEditorOpen={true}

--- a/src/components/Navigation.tsx
+++ b/src/components/Navigation.tsx
@@ -178,15 +178,6 @@ export default function Navigation(props: Props) {
                 </Link>
               </li>
             ))}
-            {isSignatures && category === 'GraphQL' && (
-              <li>
-                <a
-                  className="block border-l pl-4 -ml-px border-transparent hover:border-gray-400 text-primary-600 hover:text-deep-purple-900 hover:font-medium"
-                  href="https://signatures-api.criipto.com/v1/explorer"
-                  target="_blank"
-                >Explorer</a>
-              </li>
-            )}
           </ul>
         </li>
       ))}

--- a/src/layouts/fullscreen.tsx
+++ b/src/layouts/fullscreen.tsx
@@ -1,0 +1,8 @@
+import React from 'react';
+export default function FullscreenLayout(props: {children: React.ReactNode}) {
+  return (
+    <React.Fragment>
+      {props.children}
+    </React.Fragment>
+  );
+}

--- a/src/pages/signatures/graphql/endpoints.mdx
+++ b/src/pages/signatures/graphql/endpoints.mdx
@@ -26,4 +26,6 @@ curl https://signatures-api.criipto.com/v1/graphql
 
 ## Explorer
 
-A general purpose GraphQL Explorer is available at [https://signatures-api.criipto.com/v1/explorer](https://signatures-api.criipto.com/v1/explorer)
+A general purpose GraphQL Explorer is available at [GraphQL > Explorer](https://docs.criipto.com/signatures/graphql/explorer).
+
+The explorer connects to the GraphQL endpoint, so it is always up-to-date.

--- a/src/pages/signatures/graphql/explorer.mdx
+++ b/src/pages/signatures/graphql/explorer.mdx
@@ -1,0 +1,12 @@
+---
+product: signatures
+category: GraphQL
+sort: 5
+title: Explorer
+subtitle: Signatures GraphQL Explorer
+layout: fullscreen
+---
+
+import GraphQLExplorer from '../../../components/GraphQLExplorer';
+
+<GraphQLExplorer fullscreen />


### PR DESCRIPTION
Rather than connecting to the GraphQL Explorer at signatures-api, we can just connect directly using the same capabilities that are used for examples.

This simplifies and centralizes how one interacts with the GraphQL interface.