### PR TITLE
Fix typos and slightly update phrasing in Signatures

### DIFF
--- a/src/components/InteractiveTour.tsx
+++ b/src/components/InteractiveTour.tsx
@@ -135,7 +135,7 @@ export default function InteractiveTour() {
           <React.Fragment>
             <H2 id={slug(TITLES.createSignatureOrder)}>{TITLES.createSignatureOrder}</H2>
             <Paragraph>
-              Signature Orders form the basic building blocks of the signatures API.
+              Signature Orders form the basic building blocks of the Signatures API.
               A Signature Order contains documents and the signatories you intend to sign them.
             </Paragraph>
             <Paragraph>
@@ -182,7 +182,7 @@ export default function InteractiveTour() {
           <React.Fragment>
             <H2 id={slug(TITLES.sign)}>{TITLES.sign}</H2>
             <Paragraph>
-              This would usually be the case where you send your signatory links to the intended targets, but in this case you can sign them manually to proceed using the links below.
+              Normally, you'd send the signatory links to your intended recipients at this step. But in this case, you can proceed by signing the documents yourself using the links below.
             </Paragraph>
             <ol>
               {signatories.map((signatory, index) => (
@@ -195,7 +195,7 @@ export default function InteractiveTour() {
               Signatories can sign in parallel, our system will take care of everything.
             </Paragraph>
             <Paragraph>
-              When you haved signed or rejected the signature order with all the signatories you added you can proceed to the next step.
+              When you have signed or rejected the signature order with all the signatories you added, you can proceed to the next step.
             </Paragraph>
             <button className="bg-primary-600 text-white font-medium py-2 px-4 rounded focus:outline-none focus:shadow-outline" onClick={() => setStep('closeSignatureOrder')}>
               Proceed to next step

--- a/src/examples/createBatchSignatory/BatchSignatoryInteractiveTour.tsx
+++ b/src/examples/createBatchSignatory/BatchSignatoryInteractiveTour.tsx
@@ -226,7 +226,7 @@ export default function InteractiveTour() {
               The signatories are signed using a single authentication, our system will take care of everything.
             </Paragraph>
             <Paragraph>
-              When you haved signed or rejected the batch signatory, you can proceed to the next step.
+              When you have signed or rejected the batch signatory, you can proceed to the next step.
             </Paragraph>
             <button className="bg-primary-600 text-white font-medium py-2 px-4 rounded focus:outline-none focus:shadow-outline" onClick={() => setStep('closeSignatureOrders')}>
               Proceed to next step

--- a/src/pages/index.mdx
+++ b/src/pages/index.mdx
@@ -8,15 +8,15 @@ subtitle: Welcome to the API documentation for Criipto Verify & Criipto Document
 
 Criipto Verify provides eID authentication as a service.
 
-For an introduction to Criipto Verify and eID, you may want to read [Getting Started](/verify/getting-started/overview).
+If you're new to Criipto Verify and electronic identities (eIDs), start with our [Getting Started](/verify/getting-started/overview) guide. 
 
-All eID services supports user authentication. With Criipto Verify you integrate using *OpenID Connect* (aka OIDC). A general introduction to OIDC with Criipto Verify is available in the section on [Using OIDC](/verify/getting-started/oidc-intro).
+All eID services support user authentication. With Criipto Verify, you integrate using *OpenID Connect* (aka OIDC). For a general overview of how OIDC works with Criipto Verify, see [Using OIDC](/verify/getting-started/oidc-intro).
 
 [Criipto Verify Documentation](/verify)
 
 ## Criipto Signatures
 
-Criipto Signatures allows you to sign any PDF document using all the national eIDs supported by Criipto Verify.
+Criipto Signatures allows you to sign any PDF document using all the [national eIDs](/verify/e-ids/) supported by Criipto Verify.
 
 Documents will be produced according to the [PAdES-LTA standard](https://www.criipto.com/blog/pades-signature-levels-explained).
 

--- a/src/pages/signatures/getting-started/document-lifecycle.mdx
+++ b/src/pages/signatures/getting-started/document-lifecycle.mdx
@@ -8,13 +8,12 @@ subtitle: Learn how Criipto Signatures handles your documents securely and safel
 
 ## Default document lifecycle
 
-- **Signature order is created:** When you create a signature order with `createSignatureOrder` you send along document blobs with it,
-upon receiving it we validate it and then encrypt it and store it on Azure servers.
-- **Signatory signs:** Whenever a signatory needs to sign a document we download and decrypt it to show it to the user,
-once the user signs we embed the signatory evidence (usually eID claims returned by Criipto Verify) inside the PDF and seal it with Criiptos AATL certificate.
-After sealing the PDF we then again encrypt it and store it on Azure servers, ready for the next person to sign.
-- **Signature order is closed:** Upon closing a signature order we apply a final document timestamp to the PDF to ensure that the data inside is valid for multiple years.
-You should always request document blobs as part of the close response as this is the last time they will be available. After closing the documents will be deleted from Criipto servers.
+- **Signature order is created:** When you create a signature order with `createSignatureOrder`, you send along document blobs with it. Upon receiving the order, we validate and encrypt it, then store it on Azure servers.
+- **Signatory signs:** Whenever a signatory needs to sign a document, we download and decrypt it to show it to the user. 
+Once the user signs, we embed the signatory evidence (usually eID claims returned by Criipto Verify) inside the PDF and seal it with Criipto's AATL certificate.
+After sealing the PDF, we encrypt it again and store it on Azure servers, ready for the next person to sign.
+- **Signature order is closed:** Upon closing a signature order, we apply a final document timestamp to the PDF to ensure that the data inside is valid for multiple years.
+You should always request document blobs as part of the close response, as this is the last time they will be available. After closing the order, the documents will be deleted from Criipto's servers.
 
 You can download your document from the Criipto Signatures API at any point **up until after `closeSignatureOrder` is called**.
 
@@ -22,15 +21,15 @@ Auto-expired and cancelled signature orders also have their documents automatica
 
 ## Encryption and storage
 
-Documents are stored in Azure Datacenters in Europe, documents are always encrypted.
+Documents are stored in Azure Datacenters in Europe. Documents are always encrypted.
 
 ## Extended lifecycle
 
-If you wish to extend document lifetime so that it exists on Criiptos servers beyond `closeSignatureOrder` you can send `{retainDocumentsForDays: [number 1-7]}` as input to `closeSignatureOrder`.
-The documents will then stay available on the signature order until the configured amount of days has passed where at which point they will be deleted from Criiptos servers.
+If you wish to extend document lifetime so that it exists on Criiptos servers beyond `closeSignatureOrder`, you can send `{retainDocumentsForDays: [number 1-7]}` as input to `closeSignatureOrder`.
+The documents will then stay available on the signature order until the configured amount of days has passed. After that, they will be deleted from Criipto's servers.
 
-To ensure the highest protection of personal data you **must** make sure to clean up signature orders as soon as you can verify you have securely stored documents on your own servers, you can do so by calling the `cleanupSignatureOrder` mutation.
-The `cleanupSignatureOrder` is idempotent. If you are ever in a situation where you are uncertain about whether the clean-up mutation succeed, it is better to try it again than not doing anything.
+To ensure the highest protection of personal data, you **must** make sure to clean up signature orders as soon as you can verify you have securely stored documents on your own servers. You can do so by calling the `cleanupSignatureOrder` mutation.
+The `cleanupSignatureOrder` is idempotent. So if you're ever uncertain about whether the clean-up mutation succeeded, it's perfectly safe (and recommended) to run it again.
 
 import GraphQLExample from '../../../components/GraphQLExample';
 import * as closeSignatureOrderExample from '../../../examples/closeSignatureOrder.graphql';

--- a/src/pages/signatures/getting-started/graphql-primer.mdx
+++ b/src/pages/signatures/getting-started/graphql-primer.mdx
@@ -3,15 +3,15 @@ product: signatures
 category: Getting Started
 sort: 1
 title: A primer on GraphQL
-subtitle: Learn about GraphQL, how it works, and how to use it
+subtitle: Learn about GraphQL, how it works, and how to use it.
 ---
 
 Every GraphQL API, including ours, is backed by a strongly typed GraphQL schema.
-The schema clearly defines what operations are supported by the API, allowing clients to verify correctness ahead of time.
+The schema clearly defines what operations the API supports, allowing clients to verify correctness ahead of time.
 
 ## What's GraphQL?
 
-GraphQL is a query language, created by Facebook in 2012. They have been using it internally and in production for a while, and more recently they have published a specification for it, which has received a really positive response from the developer community. Companies like GitHub, Pinterest, and Coursera, have already started adopting it and using externally and internally.
+GraphQL is a query language created by Facebook in 2012. They have been using it internally and in production for a while, and more recently they have published a specification for it, which has received a really positive response from the developer community. Companies like GitHub, Pinterest, and Coursera have already started adopting it and using it externally and internally.
 
 A few advantages of using GraphQL are:
 
@@ -22,7 +22,7 @@ A few advantages of using GraphQL are:
 - **Strongly typed** - you can validate a query syntactically and within the GraphQL type system before execution. This also helps leverage powerful tools that improve the development experience, such as code generation.
 
 One big advantage when using GraphQL is having an efficient way to get resources by querying for exactly what you need.
-You will never need to perform multiple API calls to stich together data.
+You'll never need to perform multiple API calls to stitch data together.
 
 Here's an example GraphQL query to retrieve a specific person from our API:
 
@@ -66,7 +66,7 @@ And here is an example response:
 
 GraphQL queries can be executed against `https://signatures-api.criipto.com/v1/graphql`.
 
-Queries must be sent as a `POST` request containing a `JSON` body with the parameters `query` and optionally `variables`.
+Queries must be sent as a `POST` request containing a `JSON` body with the parameters `query` and (optionally) `variables`.
 
 You will need a set of API credentials to execute queries, please see [Registering your application](/signatures/getting-started/register-application/)
 

--- a/src/pages/signatures/getting-started/interactive-tour.mdx
+++ b/src/pages/signatures/getting-started/interactive-tour.mdx
@@ -3,7 +3,7 @@ product: signatures
 category: Getting Started
 sort: 3
 title: Interactive tour
-subtitle: Take an interactive tour through the GraphQL queries/mutations required to setup a signature flow.
+subtitle: Take an interactive tour through the GraphQL queries/mutations required to set up a signature flow.
 layout: default
 ---
 

--- a/src/pages/signatures/getting-started/register-application.mdx
+++ b/src/pages/signatures/getting-started/register-application.mdx
@@ -12,11 +12,9 @@ To start working with the Criipto Signatures API and using the [GraphQL examples
 
 To register a new Signatures application:
 
-1. Go to the [Criipto Dashboard](https://dashboard.criipto.com)
-2. Select **Test environment** from the dropdown in the top-left corner. 
-3. Navigate to **Applications** 
-4. Click **Add application** and choose **Signatures**
-5. Fill out and submit the application form
+1. Go to the [Criipto Dashboard](https://dashboard.criipto.com/applications/add?tags=signatures)
+2. Select **Test environment** from the dropdown in the top-left corner
+3. Fill out and submit the application form
 
 After creating the application, your client credentials will be shown in a popup.
 

--- a/src/pages/signatures/getting-started/register-application.mdx
+++ b/src/pages/signatures/getting-started/register-application.mdx
@@ -3,24 +3,24 @@ product: signatures
 category: Getting Started
 sort: 0
 title: Registering your Application
-subtitle: You will need to register an application with Criipto to get the required credentials (client id and secret) to interact with the Criipto Document Signatures GraphQL API
+subtitle: To interact with the Criipto Signatures API, you must register a test application and get a set of client credentials.
 ---
 
 ## Setting up a test application
 
-To start using the GraphQL examples shown here in our documentation you will need to register a test application to get a set of client credentials.
+To start working with the Criipto Signatures API and using the [GraphQL examples](/signatures/graphql/examples), you'll need to register a test application to obtain your client credentials (**Client ID** and **Client Secret**).
 
-A signatures application can be registed by:
+To register a new Signatures application:
 
-1. Going to [Criipto Verify](https://dashboard.criipto.com/applications/add?tags=signatures)
-2. Selecting the "Test" environment
-3. Navigating to "Applications"
-4. Click the button "+ Signatures"
-5. Filling out the form and clicking submit
+1. Go to the [Criipto Dashboard](https://dashboard.criipto.com)
+2. Select **Test environment** from the dropdown in the top-left corner. 
+3. Navigate to **Applications** 
+4. Click **Add application** and choose **Signatures**
+5. Fill out and submit the application form
 
-After creating the application your client credentials should be shown in a popup.
+After creating the application, your client credentials will be shown in a popup.
 
-Please store the credentials in a safe location. You can refresh or delete client credentials at any time.
+Please store them in a safe location. You can refresh or delete your client credentials at any time.
 
 _________________
 

--- a/src/pages/signatures/getting-started/ui-customization.mdx
+++ b/src/pages/signatures/getting-started/ui-customization.mdx
@@ -3,15 +3,15 @@ product: signatures
 category: Getting Started
 sort: 4
 title: UI Customization
-subtitle: The signatory frontend UI can be easily be customized with your logo and theme colors.
+subtitle: The signatory frontend UI can be easily customized with your logo and theme colors.
 ---
 
 The goal of Criipto Signatures is to be fully customizable to fit exactly into your workflow.
-In the short term you can set a logo and theme the UI via CSS variables.
+In the short term, you can set a logo and theme the UI via CSS variables.
 
-All UI settings are signature order specific which makes it easy for you to customize based on the context, and you can easily test new UI settings without affecting any new signature orders.
+All UI settings are signature-order-specific, which makes it easy for you to customize based on the context. Plus, you can easily test new UI settings without affecting any new signature orders.
 
-When creating a signature order via `createSignatureOrder` you can customize the UI by defining the subproperties of the `ui` input variable.
+When creating a signature order via `createSignatureOrder`, you can customize the UI by defining the subproperties of the `ui` input variable.
 
 [Full UI settings GraphQL Example](/signatures/graphql/examples/#signature-order-ui-settings)
 
@@ -19,7 +19,7 @@ When creating a signature order via `createSignatureOrder` you can customize the
 
 A logo can be added to the top of the signatory screen.
 
-Set `ui.logo.src` to an absolute HTTPs image url and we will add the image to the top of the signatory frontend.
+Set `ui.logo.src` to an absolute HTTPs image url, and we will add the image to the top of the signatory frontend.
 
 You can also define `ui.logo.href` which turns the logo into a link.
 
@@ -40,7 +40,7 @@ You can also define `ui.logo.href` which turns the logo into a link.
 
 A custom stylesheet can be added to the frontend to provide unique theming and styling options.
 
-Set `ui.stylesheet` to an absolute HTTPs css url and it will be loaded when the signatory opens their link.
+Set `ui.stylesheet` to an absolute HTTPs css url, and it will be loaded when the signatory opens their link.
 
 ```text
 {
@@ -62,13 +62,13 @@ The fastest way to theme the UI would be to override our CSS variables to show y
 
 ### Storybook
 
-You can test your stylesheet without creating a signature order by using our Storybook (BETA) which is a static rendering of our UI with dummy data.
+You can test your stylesheet without creating a signature order by using our Storybook (BETA), which is a static rendering of our UI with dummy data.
 
-[Open the Signatures Storybook](https://signatures-storybook.criipto.com) and then paste a stylesheet URL into the "Stylesheet URL" input field, you can use `https://signatures-storybook.criipto.com/custom.css` to test.
+[Open the Signatures Storybook](https://signatures-storybook.criipto.com) and paste a stylesheet URL into the "Stylesheet URL" input field. You can use `https://signatures-storybook.criipto.com/custom.css` to test.
 
 ### CSS Variables
 
-Below you will find a list of all CSS variables that can currently be overriden.
+Below you will find a list of all CSS variables that can currently be overridden.
 
 ```text
 .criipto-signatures {

--- a/src/pages/signatures/graphql/examples.mdx
+++ b/src/pages/signatures/graphql/examples.mdx
@@ -41,7 +41,7 @@ import criiptoVerifyOptionsExample from '../../../examples/createSignatureOrder/
 
 ### Requiring evidence validation before viewing documents
 
-If your documents contain PII (before being signed) you may wish to enforce that the signatory validates their identitiy before viewing the documents.
+If your documents contain PII (before being signed), you may wish to enforce that the signatory validates their identity before viewing the documents.
 
 import evidenceValidationStagesExample from '../../../examples/createSignatureOrder/evidenceValidationStages';
 
@@ -57,7 +57,7 @@ import uiExample from '../../../examples/createSignatureOrder/ui';
 
 ### Requiring unique eIDs for each signatory
 
-If you do not wish signatories to be able to sign multiple times (i.e. not using a "role" system or just have issues with persons sharing eID).
+If you do not wish signatories to be able to sign multiple times (i.e. not using a "role" system or just have issues with persons sharing eID),
 you can configure the Criipto Verify evidence provider to enforce uniqueness via the `uniqueEvidenceKey: 'sub'` setting.
 
 import uniqueEvidenceKeyExample from '../../../examples/createSignatureOrder/uniqueEvidenceKey';
@@ -84,7 +84,7 @@ import changeSignatureOrderBasicExample from '../../../examples/changeSignatureO
 
 ## Adding a signatory to a signature order
 
-Signatories are the individuals you wish to have sign a specific `signatureOrder`. Once created they will have a unique link that you can redirect users to.
+Signatories are the individuals you intend to sign a specific `signatureOrder`. Once created, each signatory is assigned a unique link that you can use to redirect them to the signing process.
 
 import addSignatoryBasicExample from '../../../examples/addSignatory/basic';
 
@@ -96,7 +96,7 @@ If you wish to validate the user signing, you should use the `evidenceValidation
 
 Evidence validation keys must match what will be found in the token claims when signing. You can inspect the [JWTs issued by Criipto Verify](https://docs.criipto.com/verify/getting-started/token-contents/) to see the keys that can be used for evidence validation. _Tip: Hover over a claim in the JWT payload to view its description._
 
-Evidence will be hashed before storage and compared when a user tries to sign. If the evidence does not match an error will be displayed to the user and they will be prompted to try again.
+Evidence will be hashed before storage and compared when a user tries to sign. If the evidence does not match, an error will be displayed to the user, and they will be prompted to try again.
 
 import addSignatoryEvidenceValidationExample from '../../../examples/addSignatory/evidenceValidation';
 
@@ -104,7 +104,7 @@ import addSignatoryEvidenceValidationExample from '../../../examples/addSignator
 
 ### UI Settings
 
-By default a signatory inherits its UI settings from the signature order, but it is also possible to
+By default, a signatory inherits their UI settings from the signature order, but it is also possible to
 define this on a per-signatory basis, to support specific languages per user, etc.
 
 import addSignatoryuiExample from '../../../examples/addSignatory/ui';
@@ -121,7 +121,7 @@ import addSignatoryRoleExample from '../../../examples/addSignatory/role';
 
 ### Document scoping
 
-By using the `documents` input array for `addSignatory` you can limit what documents a signatory will be shown.
+By using the `documents` input array for `addSignatory`, you can limit what documents a signatory will be shown.
 
 import addSignatoryDocumentsExample from '../../../examples/addSignatory/documents';
 
@@ -129,11 +129,11 @@ import addSignatoryDocumentsExample from '../../../examples/addSignatory/documen
 
 ### Preapproval
 
-For scenarios where you are displaying the PDFs to the users in your own UI you can opt to create a signatory with the documents preapproved.
+For scenarios where you are displaying the PDFs to the users in your own UI, you can opt to create a signatory with the documents preapproved.
 
-By preapproving documents for a signatory they are immediately sent to eID login to sign and skip the frontend approval flow.
+By preapproving documents for a signatory, they are immediately sent to the eID login to sign and skip the frontend approval flow.
 
-When using preapproval document-scoping is automatically used so make sure that you pass all documents from the signature order to the signatory.
+When using preapproval, document-scoping is automatically used so make sure that you pass all documents from the signature order to the signatory.
 
 import addSignatoryPreapprovedExample from '../../../examples/addSignatory/preapproved';
 
@@ -141,7 +141,7 @@ import addSignatoryPreapprovedExample from '../../../examples/addSignatory/preap
 
 ### Custom seal position
 
-If you do not wish to use the default seal positions (placed in two columns on a blank page appended to the order) you can define a set of custom seal positions.
+If you do not wish to use the default seal positions (placed in two columns on a blank page appended to the order), you can define a set of custom seal positions.
 
 When using custom seal positions, they must be defined for all signatories added to the order.
 
@@ -153,7 +153,7 @@ import addSignatorySealPositionExample from '../../../examples/addSignatory/seal
 
 ### Multiple signatories
 
-If you need to add signatories in bulk you can use the `addSignatories` mutation.
+If you need to add signatories in bulk, you can use the `addSignatories` mutation.
 `addSignatories` supports a `signatories` input array, where each array item supports the same input values as `addSignatoryMutation`.
 
 import addSignatoriesExample from '../../../examples/addSignatories/basic';
@@ -175,13 +175,13 @@ import addSignatoryOverrideEvidenceProviderSettings from '../../../examples/addS
 
 <GraphQLExample example={addSignatoryOverrideEvidenceProviderSettings} />
 
-## Signature Apperance
+## Signature Appearance
 
-Signature apperance (inside the PDF/document) can be configured via the `signatureAppearance` input object on `createSignatureOrder`.
+Signature appearance (inside the PDF/document) can be configured via the `signatureAppearance` input object on `createSignatureOrder`.
 
 The example below shows how you might configure it to show the `social number / cpr number` instead of a GUID for any SE/DK/NO login while also accounting for simple and complex claim types.
 
-If dealing with a single eID (like Swedish BankID) and only simple claims you can configure it as simply `identifierFromEvidence: ["ssn"]`
+If dealing with a single eID (like Swedish BankID) and only simple claims, you can configure it as simply `identifierFromEvidence: ["ssn"]`.
 
 import createSignatureAppearanceExample from '../../../examples/createSignatureOrder/signatureAppearance';
 
@@ -189,9 +189,9 @@ import createSignatureAppearanceExample from '../../../examples/createSignatureO
 
 ### Variable Templating
 
-Templating in signature seals can happen in either the left side of the header, the display name or the footer.
+Templating in signature seals can happen in either the left side of the header, the display name, or the footer.
 
-Variable templating works by enclosing the referenced variable curly brackets, e.g. `{{my-identifier}}`
+Variable templating works by enclosing the referenced variable in curly brackets, e.g. `{{my-identifier}}`
 
 In addition to templating values from claims (see [Seal display name](#seal-display-name)), we enable use of some additional variables, such as:
 
@@ -209,9 +209,9 @@ In addition to templating values from claims (see [Seal display name](#seal-disp
 
 ### Seal timestamp
 
-By default the seal renders a timestamp in the left side of the seal header.
+By default, the seal renders a timestamp on the left side of the seal header.
 
-This can be customized (per signatory) to either override the timestamp format, or change the values displayed by using available claims.
+This can be customized (per signatory) to either override the timestamp format or change the values displayed by using available claims.
 
 Below is an example of how to modify the timestamp formatting:
 
@@ -221,13 +221,13 @@ import addSignatoryHeaderLeftExample from '../../../examples/addSignatory/header
 
 ### Seal display name
 
-By default the seal renders a name via the standard JWT name claim or via drawable name input.
+By default, the seal renders a name via the standard JWT name claim or via a drawable name input.
 
-This can be customized (per signatory) to either override the name completely, or build a new name syntax from available claims.
+This can be customized (per signatory) to either override the name completely or build a new name syntax from available claims.
 
 Below is an example of how one might render a business name together with the username, and fallback to a non-business scenario.
 
-This feature currently ONLY works with CriiptoVerify/OIDC based signatures.
+This feature currently ONLY works with CriiptoVerify/OIDC-based signatures.
 
 import addSignatoryDisplayNameExample from '../../../examples/addSignatory/displayName';
 
@@ -235,7 +235,7 @@ import addSignatoryDisplayNameExample from '../../../examples/addSignatory/displ
 
 ### Seal document ID
 
-By default the seal does not render the document ID.
+By default, the seal does not render the document ID.
 
 The document ID can be added to the seal by templating as shown in the following example:
 
@@ -245,7 +245,7 @@ import addSignatoryFooterExample from '../../../examples/addSignatory/footer';
 
 ## Closing a signature order
 
-When all signatories have signed the signature order you can close it to retrieve your signed PDFs.
+When all signatories have signed the signature order, you can close it to retrieve your signed PDFs.
 
 The PDFs are deleted from Criipto servers upon calling `closeSignatureOrder`. (Unless you define the `retainDocumentsForDays` setting.)
 
@@ -265,7 +265,7 @@ import retentionCloseSignatureOrderExample from '../../../examples/closeSignatur
 
 When retrieving document blobs for a signature order, you can also request information about the signatures embedded in the document.
 
-For users signing with an eID, this will include the `jwt` issued which can be validated against the also-returned `jwks` and decoded to provide the underlying claims (like ssn or other eID claim values).
+For users signing with an eID, this will include the issued `jwt`, which can be validated against the also-returned `jwks` and decoded to provide the underlying claims (like ssn or other eID claim values).
 
 import * as closeSignatureOrderExample from '../../../examples/closeSignatureOrder.graphql';
 
@@ -273,7 +273,7 @@ import * as closeSignatureOrderExample from '../../../examples/closeSignatureOrd
 
 ## Cancel a signature order
 
-If for any reason you no longer need a signature order you can abandon it by using `cancelSignatureOrder`
+If, for any reason, you no longer need a signature order, you can abandon it by using `cancelSignatureOrder`
 
 import cancelSignatureOrderExample from '../../../examples/cancelSignatureOrder/basic';
 
@@ -289,7 +289,7 @@ import createDrawableExample from '../../../examples/createSignatureOrder/drawab
 
 <GraphQLExample example={createDrawableExample} />
 
-### Adding a signatory with selectively enabled evidence provider
+### Adding a signatory with a selectively enabled evidence provider
 
 You can define `evidenceProviders` with `enabledByDefault: false` and then selectively enabling them using the `evidenceProviders` array input for `addSignatory`.
 
@@ -297,7 +297,7 @@ import addSignatoryDrawableExample from '../../../examples/addSignatory/drawable
 
 <GraphQLExample example={addSignatoryDrawableExample} />
 
-### Changing a signatory to selectively enable a evidence provider
+### Changing a signatory to a selectively enabled evidence provider
 
 You can define `evidenceProviders` with `enabledByDefault: false` and then selectively enabling them using the `evidenceProviders` array input for `changeSignatory`.
 
@@ -309,9 +309,9 @@ import changeSignatoryDrawableExample from '../../../examples/changeSignatory/dr
 
 The common case is to let signatories sign via their browser with an eID, this also provides the highest level of evidence.
 
-However if you wish to sign acting as a signatory, for example to automatically counter-sign documents with a specific image, you can use the `signActingAs` mutation.
+However, if you wish to sign acting as a signatory, for example, to automatically counter-sign documents with a specific image, you can use the `signActingAs` mutation.
 
-Any signatory used **MUST be **[**preapproved**](#preapproval) as the API can no longer garantuee that the signatory has seen and approved the document.
+Any signatory used **MUST be **[**preapproved**](#preapproval) as the API can no longer guarantee that the signatory has seen and approved the document.
 
 import * as signActingAsExample from '../../../examples/signActingAs.graphql';
 
@@ -321,7 +321,7 @@ import * as signActingAsExample from '../../../examples/signActingAs.graphql';
 
 In certain cases where signed documents need to be printed, it can be beneficial to have signatories sign both with an eID and a drawable signature.
 
-The API supports defining an `allOf` evidence provider that is a composite of multiple other evidence providers. The order of the list defines the order the signatory is asked to sign in.
+The API supports defining an `allOf` evidence provider that is a composite of multiple other evidence providers. The order of the list defines the order in which the signatory will be asked to sign.
 
 import compositeAllOfExample from '../../../examples/createSignatureOrder/composite-allOf';
 

--- a/src/pages/signatures/graphql/examples.mdx
+++ b/src/pages/signatures/graphql/examples.mdx
@@ -227,7 +227,7 @@ This can be customized (per signatory) to either override the name completely or
 
 Below is an example of how one might render a business name together with the username, and fallback to a non-business scenario.
 
-This feature currently ONLY works with CriiptoVerify/OIDC-based signatures.
+This feature currently ONLY works with CriiptoVerify-based signatures.
 
 import addSignatoryDisplayNameExample from '../../../examples/addSignatory/displayName';
 

--- a/src/pages/signatures/guides/PdfFormFillingTour.tsx
+++ b/src/pages/signatures/guides/PdfFormFillingTour.tsx
@@ -188,7 +188,7 @@ export default function InteractiveTour() {
           <React.Fragment>
             <H3 className="mt-2" id={slug(TITLES.sign)}>{TITLES.sign}</H3>
             <Paragraph>
-              This would usually be the case where you send your signatory links to the intended targets, but in this case you can sign them manually to proceed using the links below.
+              Normally, you'd send the signatory links to your intended recipients at this step. But in this case, you can proceed by signing the documents yourself using the links below.
             </Paragraph>
             <ol>
               {signatories.map((signatory, index) => (
@@ -198,7 +198,7 @@ export default function InteractiveTour() {
               ))}
             </ol>
             <Paragraph>
-              When you haved signed you can proceed to the next step.
+              When you have signed, you can proceed to the next step.
             </Paragraph>
             <button className="bg-primary-600 text-white font-medium py-2 px-4 rounded focus:outline-none focus:shadow-outline" onClick={() => setStep('closeSignatureOrder')}>
               Proceed to next step

--- a/src/pages/signatures/index.mdx
+++ b/src/pages/signatures/index.mdx
@@ -1,7 +1,7 @@
 ---
 product: signatures
 title: Criipto Signatures
-subtitle: Sign PDF documents with national eIDs and the PAdES standard
+subtitle: Sign documents with national eIDs and the PAdES standard
 ---
 
 Criipto Signatures allows you to sign any PDF document using all the [national eIDs](/verify/e-ids/) supported by Criipto Verify.

--- a/src/pages/signatures/index.mdx
+++ b/src/pages/signatures/index.mdx
@@ -1,12 +1,12 @@
 ---
 product: signatures
 title: Criipto Signatures
-subtitle: Sign documents and PDFs with national eIDs and the PAdES standard
+subtitle: Sign PDF documents with national eIDs and the PAdES standard
 ---
 
-Criipto Signatures allows you to sign any PDF document using all the national eIDs supported by Criipto Verify.
+Criipto Signatures allows you to sign any PDF document using all the [national eIDs](/verify/e-ids/) supported by Criipto Verify.
 
 Documents will be produced according to the [PAdES-LTA standard](https://www.criipto.com/blog/pades-signature-levels-explained).
 
-- **Getting Started**. If you are not yet familiar with GraphQL or have not yet registed a Criipto Signatures application please follow our [Getting Started guide](/signatures/getting-started/register-application)
-- **GraphQL**. The Criipto Signature API is built with GraphQL enabling you to build a unique workflow matching your exact needs, have a look at our [GraphQL Examples](/signatures/graphql/examples)
+- **Getting Started**. If you are new to GraphQL or have not yet registed a Criipto Signatures application, please follow our [Getting Started guide](/signatures/getting-started/register-application).
+- **GraphQL**. The Criipto Signatures API is built with GraphQL, enabling you to create unique workflows tailored to your needs. Have a look at our [GraphQL Examples](/signatures/graphql/examples) to see how it works in practice. 


### PR DESCRIPTION
Noticed some typos in the docs while writing sales material for Criipto Signatures. 