### PR TITLE
Update AusweisApp simulator setup instructions

### DIFF
--- a/src/pages/verify/e-ids/german-personalausweis.mdx
+++ b/src/pages/verify/e-ids/german-personalausweis.mdx
@@ -72,14 +72,16 @@ To configure the desktop AusweisApp to use the simulator, follow these steps:
 8. On the *Developer options* page:
     1. Toggle *Testmode for the self-authentication* to be "on" (toggle button to the right)
     2. Toggle *Internal card simulator* to be "on" (toggle button to the right)
-9. Tap *Start* (on the bottom bar) to go back to the *Start* page
+9. On the *Settings* page, scroll back up to the top, where you should see *General*
+10. On the *General* page, tap *Readout mode* and select *by internal card simulator*
+11. Tap *Start* (on the bottom bar) to go back to the *Start* page
 
-The AusweisApp will now allow you to select the Simulator during authentications.
+The AusweisApp will now use the Simulator during authentications.
 You can test this by swiping to the right and tapping *See my personal data* on the *Start* page, then proceeding through the flow as follows:
 1. Tap *See my personal data*
 2. Tap *Proceed to PIN entry*
-3. On the *Identify* screen, you should now be able to select *SIM* (instead of just *NFC* and *WiFi*)
-4. Select *SIM* and then tap *Continue*
+3. On the *Identify* screen, the app will now show *Simulator* (and allow you to switch back to *NFC* or *WiFi*)
+4. Tap *Continue*
 
 The AusweisApp should now skip the card scanning step and you should see the data for the test user Erika Mustermann.
 


### PR DESCRIPTION
The AusweisApp has recently updated, and now needs and extra step to use the card simulator.