### PR TITLE
Add page on eID caveats for Signatures

### DIFF
--- a/src/pages/signatures/guides/eid-special-configuration.mdx
+++ b/src/pages/signatures/guides/eid-special-configuration.mdx
@@ -1,0 +1,27 @@
+---
+product: signatures
+category: Guides
+sort: 30
+title: eID Special Configuration
+subtitle: eID caveats for Signatures
+---
+
+Some eIDs require additional configuration when configuring authentication parameters to work.
+
+## German Personalausweis
+
+In test environment, you will need to add `login_hint=txinfo:{sometext}` as described in [Verify German Personalausweis documentation](/verify/e-ids/german-personalausweis/#test-authorize-requests).
+
+## Dutch iDIN
+
+By default, Signatures provides a display name template by combining the `given_name` and `family_name` from the JWT claims.
+To retrieve name information from iDIN, you will need to provide an additional scope on either signature order or sigantory level to enable [full identification](https://docs.criipto.com/verify/e-ids/dutch-idin/#full-identification).
+
+`scope=openid idin:full-id` - `openid` is required by default, and by setting the scope, the default value is overwritten.
+
+## FrejaID
+
+By default, Signatures provides a display name template by combining the `given_name` and `family_name` from the JWT claims.
+Name information can be retrieved from FrejaID by providing an additional [scope](/verify/e-ids/frejaid/#scopes-for-frejaid), **however**, [setting a minimum registration level](/verify/e-ids/frejaid/#setting-a-minimum-registration-level) of at least "Extended" is required.
+
+`scope=openid freja:basic_user_info` AND `loginHint=minregistrationlevel:{extended,plus}` - `openid` is required by default, and by setting the scope, the default value is overwritten.


### PR DESCRIPTION
In some cases, eID requires some additional configuration to provide information such as names for the signature seals. The page describes some additional configuration required for German Personalausweis, Dutch iDIN and FrejaID.