### PR TITLE
Fix document index

### DIFF
--- a/src/examples/addSignatory/documents.graphql.ts
+++ b/src/examples/addSignatory/documents.graphql.ts
@@ -8,8 +8,11 @@ export const variables = (data: ExampleData) : {input: AddSignatoryInput} => ({
     ...basic.variables(data).input,
     documents: [
       {
-        id: data.createSignatureOrder?.signatureOrder.documents[1].id || "[signatureOrder.documents[...].id]"
-      }
-    ]
-  }
+        id:
+          data.createSignatureOrder?.signatureOrder.documents[1]?.id ??
+          (data.createSignatureOrder?.signatureOrder.documents[0]?.id ||
+            '[signatureOrder.documents[...].id]'),
+      },
+    ],
+  },
 });


### PR DESCRIPTION
We're using the signature order with 2 documents to demonstrate that one can add a subset of documents to a signatory. However, it breaks the mutations where a signature order is created with a single document. This PR fixes that.