### PR TITLE
Remove semicolons rendering as content

### DIFF
--- a/src/components/GraphQLQueryBuilder/addSignatory.tsx
+++ b/src/components/GraphQLQueryBuilder/addSignatory.tsx
@@ -185,7 +185,7 @@ export default function AddSignatoryQueryBuilder() {
           </div>
         ))}
       </div>
-      <GraphQLExample example={{query, variables}} />;
+      <GraphQLExample example={{query, variables}} />
     </React.Fragment>
   )
 }

--- a/src/components/GraphQLQueryBuilder/createSignatureOrder.tsx
+++ b/src/components/GraphQLQueryBuilder/createSignatureOrder.tsx
@@ -199,7 +199,7 @@ export default function CreateSignatureOrderQueryBuilder() {
           </select>
         </div>
       </div>
-      <GraphQLExample example={{query, variables}} />;
+      <GraphQLExample example={{query, variables}} />
     </React.Fragment>
   );
 }


### PR DESCRIPTION
We had two semicolons rendered as text in Query Builder: 
<img width="303" height="509" alt="Screenshot 2025-08-13 at 11 08 34" src="https://github.com/user-attachments/assets/6d6ab20f-fc20-4e77-a1c9-2d6fb91dee9f" />
<img width="455" height="583" alt="Screenshot 2025-08-13 at 11 06 06" src="https://github.com/user-attachments/assets/40e95b46-55cc-4c40-b8f7-23c00f6f1208" />
