### PR TITLE
Add document photo to Freja restricted attrs.

### DIFF
--- a/src/pages/verify/e-ids/frejaid.mdx
+++ b/src/pages/verify/e-ids/frejaid.mdx
@@ -151,6 +151,7 @@ Contact support if you would like to use them:
 - `unique_personal_identifier`: a unique personal identifier which can be used to link FrejaID users across services
 - `loa_level`: the eIDAS Level of Assurance of the user
 - `custom_identifier`: a custom identifier registered by your organization in FrejaID's systems
+- `document_photo`: a photo of the user's registration document
 
 ### Setting a minimum registration level
 Some scopes are only available for certain registration levels.


### PR DESCRIPTION
This is not documented in Freja's documentation, but we must request this to be enabled in production for our customers before it will work.