### PR TITLE
Update app switching docs

### DIFF
--- a/src/pages/verify/guides/appswitch.mdx
+++ b/src/pages/verify/guides/appswitch.mdx
@@ -16,8 +16,8 @@ You should always start by detecting the presence of the native eID app on the u
 
 If the desired app is present on the users device, you must augment the authorize request you send to Criipto Verify so it contains one of the following values (also OS dependent)
 
- - `login_hint=appswitch:ios`
- - `login_hint=appswitch:android`
+- `login_hint=appswitch:ios`
+- `login_hint=appswitch:android`
 
 The value must be sent in the `login_hint` query parameter. Further details on this (and other) parameters in an authorize request can be found [here](/verify/getting-started/oidc-intro#authorize-request-parameters).
 
@@ -36,6 +36,7 @@ We have therefore removed the previous guidance for MitID app detection from our
 The following code and configuration snippets illustrate how you can detect the presence of the Swedish BankID app.
 
 #### Android
+
 ```java
 public boolean deviceHasSEBankIdApp() {
   try {
@@ -73,54 +74,6 @@ func canOpenSEBankIDApp() -> Bool {
 }
 ```
 
-### Swedish BankID
-App switch is supported for the same-device login flow (`acr_values=urn:grn:authn:se:bankid:same-device`).
-
-We recommend that you use `response_mode=json` or `response_mode=query` for this flow.
-
-For the `redirect_uri` in the authorize request, you can experiment with using either a universal link for your app, or a custom file handler. Which one is more robust depends on the version of the OS you are on. Newer OS versions typically work best with universal links.
-
-The response to the authorize request will change to `200 OK` with a JSON payload of format along the lines of:
-```json
-{
-  "launchLinks": {
-    "universalLink": "https://app.bankid.com/?autostarttoken=...&redirect=...",
-    "customFileHandlerUrl": "bankid:///?autostarttoken=...&redirect=..."
-  },
-  "cancelUrl": "...",
-  "completeUrl": "..."
-}
-```
-
-<Highlight icon="file-lines">
-
-The value of the redirect parameter depends on the supplied platform in the `login_hint=appswitch:...` parameter.
-If the app sends the wrong parameter, the flow cannot be expected to work correctly.
-
-</Highlight>
-
-Your app must use one of the `launchLinks` values to open the native BankID app. 
-The `universalLink` is recommended, but some older platforms may only support the `customFileHandlerUrl` syntax.
-We provide both so you can target the widest possible range of OS versions.
-
-The `cancelUrl` can be used to to stop an active authentication request.
-This can be useful in case 
-- You are pre-filling the SSN
-- The user does not complete the authentication in the BankID application
-- The user navigates manually back to your app  
-
-When that happens, the BankID login for the specified SSN is blocked for a few minutes, unless you cancel the login.
-
-When control returns to your app, issue an HTTP GET to the `completeUrl` (without any modifications).
-Expect an OAuth2-formatted response.
-Depending on the value of the `response_mode` you use in your authorize request, the response will be either a `200 OK`, a `302 Redirect`, or a `400 Bad Request`.
-
-- `200 OK`: (when sending `response_mode=json`) The response payload will be a JSON literal with a string-valued `location` property. The value will be a URL where the relevant response parameters are in the query section. You should start by checking for errors (an `error` query parameter will be present in the response). If not an error, pick out the `code` and `state` parameters and use your OIDC library to exhange the `code` to an `id_token`.
-
-- `302 Redirect`: (when sending `response_mode=query`) The Location response header value will be a URL where the relevant response parameters are in the query section. You should perform the same OAuth2-response processing as described for the `200 OK` case.
-
-- `400 Bad Request`: Can have several causes, we recommend that you invoke the `cancelUrl` and present the user with the option to login again.
-
 ### Danish MitID
 
 You must (still) use a either a `Custom Tab` (on `Android`) or an `ASWebAuthenticationSession` (on `iOS`) to run the login flow in your app, but an app-switch button will show up in the MitID Core Client, allowing the user to launch the MitID app from the browser.
@@ -133,7 +86,7 @@ If you must target very old OS versions, `SFSafariViewController` can be used as
 </Highlight>
 
 Once the flow completes, the MitID app will perform an app-switch back to your app, which makes the `Custom Tab` / `ASWebAuthenticationSession` resume its operation,
-this initial resuming of your app will not include any `OAuth2` parameters, however in resuming your app the MitID login request will continue in the web component, 
+this initial resuming of your app will not include any `OAuth2` parameters, however in resuming your app the MitID login request will continue in the web component,
 completing the login process which will issue an `OAuth2` formatted response.
 
 Assuming your `redirect_uri` is also pointing to your native app, you will need to handle two sets of deep links,
@@ -159,7 +112,7 @@ You can read more about [how App Links work here](https://developer.android.com/
 
 </Highlight>
 
-``` xml
+```xml
 <activity
         android:name=".activities.mitIDLoginActivity"
         android:launchMode="singleTop">
@@ -219,7 +172,8 @@ This has changed on June 6, 2023 (with MitID Release 11). Previously, automated 
 </Highlight>
 
 #### Working with the test-version(s) of the MitID app
+
 The test version(s) can be found here: [https://pp.mitid.dk/mitid-app/index.html](https://pp.mitid.dk/mitid-app/index.html).
 Note that on Android, the test version cannot co-exist with the production version, so you need a dedicated Android device for testing.
 On iOS, the 2 app versions can co-exist, but doing so can lead to surprising behaviour at runtime. The app-switching is (sometimes) done to the "latest active" version of the app, so you might end up in your production app while testing.
-We recommend that you always close the production version of the  MitID app before running any tests.
+We recommend that you always close the production version of the MitID app before running any tests.

--- a/src/pages/verify/guides/appswitch.mdx
+++ b/src/pages/verify/guides/appswitch.mdx
@@ -10,7 +10,11 @@ subtitle: How to use Criipto Verify in app-switch mode
 
 If you are building a native app, and would like to get the smoothest possible UX, you can use Criipto Verify's app-switching capabilities (for eIDs that support it).
 
-This will require that you take on a bit more work to orchestrate the login process in comparison with just going with the browser-based flow, but the net result is a much better UX.
+This will require that you take on a bit more work to orchestrate the login process in comparison
+with just going with the browser-based flow, but the net result is a much better UX.
+
+App switching actually includes two switches, one from your app to the verification app of the eID
+provider, and one switch back to your app, after the user has completed the verification process.
 
 You must augment the authorize request you send to Criipto Verify so it contains one of the following values (also OS dependent)
 
@@ -23,17 +27,14 @@ Your app is responsible for sending the appropriate value for the platform it is
 
 ### Danish MitID
 
-You must (still) use a either a `Custom Tab` (on `Android`) or an `ASWebAuthenticationSession` (on `iOS`) to run the login flow in your app, but an app-switch button will show up in the MitID Core Client, allowing the user to launch the MitID app from the browser.
+The initial switch to the MitID app is outside of your control. The MitID Core Client will present a
+button to the user, allowing them to switch to the MitID app, regardless of whether you set the
+`appswitch` `login_hint` parameter.
 
-<Highlight icon="file-lines">
+You must (still) use a either a `Custom Tab` (on `Android`) or an `ASWebAuthenticationSession` (on `iOS`) to run the login flow in your app.
 
-On `iOS`, you can also use `SFAuthenticationSession` if the `ASWebAuthenticationSession` is unavailable for the version you are targeting.
-If you must target very old OS versions, `SFSafariViewController` can be used as a fallback, but some features might not work properly.
-
-</Highlight>
-
-Once the flow completes, the MitID app will perform an app-switch back to your app, which makes the `Custom Tab` / `ASWebAuthenticationSession` resume its operation,
-this initial resuming of your app will not include any `OAuth2` parameters, however in resuming your app the MitID login request will continue in the web component,
+Once the flow completes, the MitID app will perform an app-switch back to your app, which makes the
+`Custom Tab` / `ASWebAuthenticationSession` resume its operation. This initial resuming of your app will not include any `OAuth2` parameters, however in resuming your app the MitID login request will continue in the web component,
 completing the login process which will issue an `OAuth2` formatted response.
 
 Assuming your `redirect_uri` is also pointing to your native app, you will need to handle two sets of deep links,

--- a/src/pages/verify/guides/appswitch.mdx
+++ b/src/pages/verify/guides/appswitch.mdx
@@ -12,9 +12,7 @@ If you are building a native app, and would like to get the smoothest possible U
 
 This will require that you take on a bit more work to orchestrate the login process in comparison with just going with the browser-based flow, but the net result is a much better UX.
 
-You should always start by detecting the presence of the native eID app on the users device. See below for [app-detection examples](#app-detection).
-
-If the desired app is present on the users device, you must augment the authorize request you send to Criipto Verify so it contains one of the following values (also OS dependent)
+You must augment the authorize request you send to Criipto Verify so it contains one of the following values (also OS dependent)
 
 - `login_hint=appswitch:ios`
 - `login_hint=appswitch:android`
@@ -22,57 +20,6 @@ If the desired app is present on the users device, you must augment the authoriz
 The value must be sent in the `login_hint` query parameter. Further details on this (and other) parameters in an authorize request can be found [here](/verify/getting-started/oidc-intro#authorize-request-parameters).
 
 Your app is responsible for sending the appropriate value for the platform it is deployed on.
-
-### App detection
-
-<Highlight icon="exclamation">
-
-From June 6, 2023 (MitID Release 11) and onwards, app-detection for MitID is no longer relevant.
-After that date, end users will be presented with "Open MitID app" buttons in the MitID Core Client, regardless of any effort by the SP's app to detect the presence of the MitID app.
-We have therefore removed the previous guidance for MitID app detection from our documentation.
-
-</Highlight>
-
-The following code and configuration snippets illustrate how you can detect the presence of the Swedish BankID app.
-
-#### Android
-
-```java
-public boolean deviceHasSEBankIdApp() {
-  try {
-    getPackageManager().getPackageInfo("com.bankid.bus", 0);
-    return true;
-  } catch (PackageManager.NameNotFoundException e) {
-    return false;
-  }
-}
-```
-
-<Highlight icon="exclamation">
-
-From Android 11, your applications `Manifest.xml` must contain the following to be able to perform this query:
-
-</Highlight>
-
-```xml
-<manifest ...>
-  <queries>
-    <package android:name="com.bankid.bus" />
-  </queries>
-  <application .... />
-</manifest>
-```
-
-#### iOS
-
-```swift
-func canOpenSEBankIDApp() -> Bool {
-  guard let url = URL(string: "https://app.bankid.com/.well-known/apple-app-site-association") else {
-    return false
-  }
-  return UIApplication.shared.canOpenURL(url)
-}
-```
 
 ### Danish MitID
 

--- a/src/pages/verify/integrations/react-native-expo.mdx
+++ b/src/pages/verify/integrations/react-native-expo.mdx
@@ -149,7 +149,7 @@ export default function LoginScreen() {
 
 ## App switch support
 
-`@criipto/verify-expo` supports app switching for [Swedish BankID](/verify/guides/appswitch/#swedish-bankid) and [Danish MitID](/verify/guides/appswitch/#danish-mitid).
+`@criipto/verify-expo` supports app switching for [Danish MitID](/verify/guides/appswitch/#danish-mitid).
 
 ### Danish MitID + Android
 

--- a/src/pages/verify/integrations/react.mdx
+++ b/src/pages/verify/integrations/react.mdx
@@ -10,7 +10,7 @@ This guide shows you how to use Criipto Verify in a React single page applicatio
 
 ## App switch support
 
-`@criipto/verify-react` supports app switching for Swedish BankID and Danish MitID by a best-effort mobile-os detection and setting the relevant Criipto Verify login hints.
+`@criipto/verify-react` supports app switching for Danish MitID by a best-effort mobile-os detection and setting the relevant Criipto Verify login hints.
 
 ## Installation
 


### PR DESCRIPTION
* App switching for SE BankID relies in a browser-less flow. This has very nice UX, but it is insecure, because a malicious app could initiate and complete the flow. So let's remove the docs.
* Removing docs on app detection, since they are no longer relevant
* Cleaning up the app switch docs
  * Mention that there are two distinct flows
  * Remove the mention of `SFAuthenticationSession` (which is deprecated). MitID [requires iOS 15](https://www.mitid.dk/hjaelp/hjaelpeunivers/tekniske-krav/), so `ASWebAuthenticationSession` is always available.

I'm wondering if it even makes sense to mention custom tabs / `ASWebAuthenticationSession` here? 🤔 They are not specifically required for app switching to work, but more of a general implementation detail when working with OIDC in native apps. `SFSafariViewController` works just as well. I realize we don't have any specific docs about native app support, but once we do, we should probably remove mention of specific web views from here.