### PR TITLE
Attempt to be more specific about the fact that customers must

### DIFF
--- a/src/pages/verify/e-ids/norwegian-bankid.mdx
+++ b/src/pages/verify/e-ids/norwegian-bankid.mdx
@@ -293,7 +293,7 @@ with answers to these questions:
 6. Contact person with authorization to receive the client credentials and client secret: _Name, mobile phone, and email_.
 7. Contact person with authorization to block/revoke the use of BankID: _Name, mobile phone, and email_.
 8. The display name to appear in the login app. E.g. the name of your company or your specific service (see the image below).
-9. The URL of your production domain as setup in step 4 of the [Getting ready for production](/verify/guides/production) guide.
+9. The URL of your Criipto Verify production domain as setup in step 4 of the [Getting ready for production](/verify/guides/production) guide.
 10. If you need access to social security numbers (“fødselsnummer”) please provide a thorough explanation of why and reference the Norwegian law and paragraph that grants you the right to receive them. If SSN is needed, then the reference to the Norwegian Law and Paragraph is mandatory.
 11. Finally - if you are not a Norwegian company - you must enclose a company certificate from the official business registry of the country of incoporation.
 


### PR DESCRIPTION
create a production domain in Criipto Verify before ordering credentials, in contrast to having a production domain ready in their own service/website/platform/...

The current wording is not abundantly clear here, and one must read the linked-to document to figure it out. 

Inspired by a question from Settla (via Håkon).